### PR TITLE
Extend the vm-memory crate to support memory hotplug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,12 @@ edition = "2018"
 default = []
 integer-atomics = []
 backend-mmap = []
+backend-mmap-atomic = ["arc-swap", "backend-mmap"]
 
 [dependencies]
 libc = ">=0.2.39"
 cast = ">=0"
+arc-swap = { version = ">=0.4.4", optional = true }
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = ">=0.3"

--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 79.3,
+  "coverage_score": 79.8,
   "exclude_path": "mmap_windows.rs",
   "crate_features": "backend-mmap"
 }

--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 79.8,
+  "coverage_score": 84.4,
   "exclude_path": "mmap_windows.rs",
   "crate_features": "backend-mmap"
 }

--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 79.0,
+  "coverage_score": 79.3,
   "exclude_path": "mmap_windows.rs",
   "crate_features": "backend-mmap"
 }

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -101,6 +101,39 @@ pub unsafe trait ByteValued: Copy + Default + Send + Sync {
     }
 }
 
+// All intrinsic types and arrays of intrinsic types are ByteValued. They are just numbers.
+macro_rules! byte_valued_array {
+    ($T:ty, $($N:expr)+) => {
+        $(
+            unsafe impl ByteValued for [$T; $N] {}
+        )+
+    }
+}
+
+macro_rules! byte_valued_type {
+    ($T:ty) => {
+        unsafe impl ByteValued for $T {}
+        byte_valued_array! {
+            $T,
+            0  1  2  3  4  5  6  7  8  9
+            10 11 12 13 14 15 16 17 18 19
+            20 21 22 23 24 25 26 27 28 29
+            30 31 32
+        }
+    };
+}
+
+byte_valued_type!(u8);
+byte_valued_type!(u16);
+byte_valued_type!(u32);
+byte_valued_type!(u64);
+byte_valued_type!(usize);
+byte_valued_type!(i8);
+byte_valued_type!(i16);
+byte_valued_type!(i32);
+byte_valued_type!(i64);
+byte_valued_type!(isize);
+
 /// A container to host a range of bytes and access its content.
 ///
 /// Candidates which may implement this trait include:
@@ -190,37 +223,6 @@ pub trait Bytes<A> {
     where
         F: Write;
 }
-
-// All intrinsic types and arrays of intrinsic types are ByteValued. They are just numbers.
-macro_rules! byte_valued_array {
-    ($T:ty, $($N:expr)+) => {
-        $(
-            unsafe impl ByteValued for [$T; $N] {}
-        )+
-    }
-}
-macro_rules! byte_valued_type {
-    ($T:ty) => {
-        unsafe impl ByteValued for $T {}
-        byte_valued_array! {
-            $T,
-            0  1  2  3  4  5  6  7  8  9
-            10 11 12 13 14 15 16 17 18 19
-            20 21 22 23 24 25 26 27 28 29
-            30 31 32
-        }
-    };
-}
-byte_valued_type!(u8);
-byte_valued_type!(u16);
-byte_valued_type!(u32);
-byte_valued_type!(u64);
-byte_valued_type!(usize);
-byte_valued_type!(i8);
-byte_valued_type!(i16);
-byte_valued_type!(i32);
-byte_valued_type!(i64);
-byte_valued_type!(isize);
 
 #[cfg(test)]
 mod tests {

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -260,6 +260,11 @@ mod tests {
                 }
             }
         }
+        // Check the early out condition
+        {
+            assert!(T::from_slice(&data).is_none());
+            assert!(T::from_mut_slice(&mut data).is_none());
+        }
     }
 
     #[test]

--- a/src/endian.rs
+++ b/src/endian.rs
@@ -117,7 +117,9 @@ mod tests {
 
                 #[allow(overflowing_literals)]
                 #[test]
-                fn equality() {
+                fn test_endian_type() {
+                    <$new_type>::_assert();
+
                     let v = 0x0123_4567_89AB_CDEF as $old_type;
                     let endian_v: $new_type = From::from(v);
                     let endian_into: $old_type = endian_v.into();
@@ -129,7 +131,9 @@ mod tests {
                         assert_eq!(endian_v, endian_transmute.swap_bytes());
                     }
 
-                    assert_eq!(v, endian_into);
+                    assert_eq!(endian_into, v);
+                    assert_eq!(endian_v.to_native(), v);
+
                     assert!(v == endian_v);
                     assert!(endian_v == v);
                 }

--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -164,7 +164,7 @@ pub trait GuestMemoryRegion: Bytes<MemoryRegionAddress, E = Error> {
     fn start_addr(&self) -> GuestAddress;
 
     /// Get maximum (inclusive) address managed by the region.
-    fn end_addr(&self) -> GuestAddress {
+    fn last_addr(&self) -> GuestAddress {
         // unchecked_add is safe as the region bounds were checked when it was created.
         self.start_addr().unchecked_add(self.len() - 1)
     }
@@ -302,10 +302,10 @@ pub trait GuestMemory {
         G: Fn(T, T) -> T;
 
     /// Get maximum (inclusive) address managed by the region.
-    fn end_addr(&self) -> GuestAddress {
+    fn last_addr(&self) -> GuestAddress {
         self.map_and_fold(
             GuestAddress(0),
-            |(_, region)| region.end_addr(),
+            |(_, region)| region.last_addr(),
             std::cmp::max,
         )
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,8 +29,8 @@ pub use endian::{Be16, Be32, Be64, BeSize, Le16, Le32, Le64, LeSize};
 
 pub mod guest_memory;
 pub use guest_memory::{
-    Error as GuestMemoryError, GuestAddress, GuestMemory, GuestMemoryRegion, GuestUsize,
-    MemoryRegionAddress, Result as GuestMemoryResult,
+    Error as GuestMemoryError, GuestAddress, GuestMemory, GuestMemoryGuard, GuestMemoryRegion,
+    GuestUsize, MemoryRegionAddress, Result as GuestMemoryResult,
 };
 
 #[cfg(all(feature = "backend-mmap", unix))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,11 @@ pub mod mmap;
 #[cfg(feature = "backend-mmap")]
 pub use mmap::{Error, GuestMemoryMmap, GuestRegionMmap, MmapRegion};
 
+#[cfg(feature = "backend-mmap-atomic")]
+pub mod mmap_atomic;
+#[cfg(feature = "backend-mmap-atomic")]
+pub use mmap_atomic::GuestMemoryMmapAtomic;
+
 pub mod volatile_memory;
 pub use volatile_memory::{
     AtomicValued, Error as VolatileMemoryError, Result as VolatileMemoryResult, VolatileArrayRef,

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -30,7 +30,8 @@ use std::sync::Arc;
 
 use crate::address::Address;
 use crate::guest_memory::{
-    self, FileOffset, GuestAddress, GuestMemory, GuestMemoryRegion, GuestUsize, MemoryRegionAddress,
+    self, FileOffset, GuestAddress, GuestMemory, GuestMemoryGuard, GuestMemoryRegion, GuestUsize,
+    MemoryRegionAddress,
 };
 use crate::volatile_memory::VolatileMemory;
 use crate::Bytes;
@@ -449,6 +450,13 @@ impl GuestMemoryMmap {
 
 impl GuestMemory for GuestMemoryMmap {
     type R = GuestRegionMmap;
+
+    fn snapshot(&self) -> GuestMemoryGuard<'_, Self>
+    where
+        Self: std::marker::Sized,
+    {
+        GuestMemoryGuard::Ref(self)
+    }
 
     fn num_regions(&self) -> usize {
         self.regions.len()
@@ -1052,6 +1060,38 @@ mod tests {
         });
         assert!(res.is_ok());
         let res: guest_memory::Result<()> = gm.with_regions_mut(|_, region| {
+            iterated_regions.push((region.start_addr(), region.len() as usize));
+            Ok(())
+        });
+        assert!(res.is_ok());
+        assert_eq!(regions, iterated_regions);
+
+        assert!(regions
+            .iter()
+            .map(|x| (x.0, x.1))
+            .eq(iterated_regions.iter().map(|x| *x)));
+
+        assert_eq!(gm.clone().regions[0].guest_base, regions[0].0);
+        assert_eq!(gm.clone().regions[1].guest_base, regions[1].0);
+    }
+
+    #[test]
+    fn test_snapshot() {
+        let region_size = 0x400;
+        let regions = vec![
+            (GuestAddress(0x0), region_size),
+            (GuestAddress(0x1000), region_size),
+        ];
+        let mut iterated_regions = Vec::new();
+        let gm = GuestMemoryMmap::new(&regions).unwrap();
+        let snapshot = gm.snapshot();
+
+        let res: guest_memory::Result<()> = snapshot.with_regions(|_, region| {
+            assert_eq!(region.len(), region_size as GuestUsize);
+            Ok(())
+        });
+        assert!(res.is_ok());
+        let res: guest_memory::Result<()> = snapshot.with_regions_mut(|_, region| {
             iterated_regions.push((region.start_addr(), region.len() as usize));
             Ok(())
         });

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -438,7 +438,7 @@ impl GuestMemoryMmap {
                 return Err(Error::UnsortedMemoryRegions);
             }
 
-            if prev.end_addr() >= next.start_addr() {
+            if prev.last_addr() >= next.start_addr() {
                 return Err(Error::MemoryRegionOverlap);
             }
         }
@@ -458,7 +458,7 @@ impl GuestMemory for GuestMemoryMmap {
         let index = match self.regions.binary_search_by_key(&addr, |x| x.start_addr()) {
             Ok(x) => Some(x),
             // Within the closest region with starting address < addr
-            Err(x) if (x > 0 && addr <= self.regions[x - 1].end_addr()) => Some(x - 1),
+            Err(x) if (x > 0 && addr <= self.regions[x - 1].last_addr()) => Some(x - 1),
             _ => None,
         };
         index.map(|x| self.regions[x].as_ref())
@@ -526,11 +526,11 @@ mod tests {
         assert_eq!(guest_mem.num_regions(), expected_regions_summary.len());
         let maybe_last_mem_reg = expected_regions_summary.last();
         if let Some((region_addr, region_size)) = maybe_last_mem_reg {
-            let mut end_addr = region_addr.unchecked_add(*region_size as u64);
-            if end_addr.raw_value() != 0 {
-                end_addr = end_addr.unchecked_sub(1);
+            let mut last_addr = region_addr.unchecked_add(*region_size as u64);
+            if last_addr.raw_value() != 0 {
+                last_addr = last_addr.unchecked_sub(1);
             }
-            assert_eq!(guest_mem.end_addr(), end_addr);
+            assert_eq!(guest_mem.last_addr(), last_addr);
         }
         for ((region_addr, region_size), mmap) in expected_regions_summary
             .iter()

--- a/src/mmap_atomic.rs
+++ b/src/mmap_atomic.rs
@@ -1,0 +1,197 @@
+// Copyright (C) 2019 Alibaba Cloud Computing. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! A default implementation of the GuestMemory trait by mmap()-ing guest's memory into the current
+//! process.
+extern crate arc_swap;
+
+use crate::guest_memory::FileOffset;
+use crate::{Error, GuestAddress, GuestMemory, GuestMemoryGuard, GuestMemoryMmap, GuestRegionMmap};
+use arc_swap::{ArcSwap, Guard};
+use std::borrow::Borrow;
+use std::result;
+use std::sync::Arc;
+
+#[derive(Debug)]
+enum Either {
+    Object(Arc<ArcSwap<GuestMemoryMmap>>),
+    Guard(Guard<'static, Arc<GuestMemoryMmap>>),
+}
+
+/// Tracks memory regions allocated/mapped for the guest in the current process.
+///
+/// This implementation uses ArcSwap to provide RCU-like lock strategy to support memory hotplug.
+/// The implementation is really a little over complex, hope that it deserves the complexity in
+/// case of performance.
+#[derive(Debug)]
+pub struct GuestMemoryMmapAtomic {
+    inner: Either,
+}
+
+impl GuestMemoryMmapAtomic {
+    /// Creates a container and allocates anonymous memory for guest memory regions.
+    /// Valid memory regions are specified as a slice of (Address, Size) tuples sorted by Address.
+    pub fn new(ranges: &[(GuestAddress, usize)]) -> result::Result<Self, Error> {
+        let mmap = GuestMemoryMmap::with_files(ranges.iter().map(|r| (r.0, r.1, None)))?;
+        Ok(GuestMemoryMmapAtomic {
+            inner: Either::Object(Arc::new(ArcSwap::new(Arc::new(mmap)))),
+        })
+    }
+
+    /// Creates a container and allocates anonymous memory for guest memory regions.
+    /// Valid memory regions are specified as a sequence of (Address, Size, Option<FileOffset>)
+    /// tuples sorted by Address.
+    pub fn with_files<A, T>(ranges: T) -> result::Result<Self, Error>
+    where
+        A: Borrow<(GuestAddress, usize, Option<FileOffset>)>,
+        T: IntoIterator<Item = A>,
+    {
+        let mmap = GuestMemoryMmap::with_files(ranges)?;
+        Ok(GuestMemoryMmapAtomic {
+            inner: Either::Object(Arc::new(ArcSwap::new(Arc::new(mmap)))),
+        })
+    }
+
+    /// Creates a new `GuestMemoryMmap` from a vector of regions.
+    ///
+    /// # Arguments
+    ///
+    /// * `regions` - The vector of regions.
+    ///               The regions shouldn't overlap and they should be sorted
+    ///               by the starting address.
+    pub fn from_regions(mut regions: Vec<GuestRegionMmap>) -> result::Result<Self, Error> {
+        Self::from_arc_regions(regions.drain(..).map(Arc::new).collect())
+    }
+
+    /// Creates a new `GuestMemoryMmap` from a vector of Arc regions.
+    ///
+    /// Similar to the constructor from_regions() as it returns a
+    /// GuestMemoryMmap. The need for this constructor is to provide a way for
+    /// consumer of this API to create a new GuestMemoryMmap based on existing
+    /// regions coming from an existing GuestMemoryMmap instance.
+    ///
+    /// # Arguments
+    ///
+    /// * `regions` - The vector of Arc regions.
+    ///               The regions shouldn't overlap and they should be sorted
+    ///               by the starting address.
+    pub fn from_arc_regions(regions: Vec<Arc<GuestRegionMmap>>) -> result::Result<Self, Error> {
+        let mmap = GuestMemoryMmap::from_arc_regions(regions)?;
+        Ok(GuestMemoryMmapAtomic {
+            inner: Either::Object(Arc::new(ArcSwap::new(Arc::new(mmap)))),
+        })
+    }
+}
+
+impl GuestMemory for GuestMemoryMmapAtomic {
+    type R = GuestRegionMmap;
+
+    fn snapshot(&self) -> GuestMemoryGuard<'_, Self>
+    where
+        Self: std::marker::Sized,
+    {
+        let inner = match self.inner {
+            Either::Object(ref obj) => Either::Guard(obj.load()),
+            Either::Guard(ref _guard) => panic!("can't create guard from guard object!!!"),
+        };
+        GuestMemoryGuard::Valued(GuestMemoryMmapAtomic { inner })
+    }
+
+    fn num_regions(&self) -> usize {
+        panic!("please use GuestMemoryMmapAtomic::snapshot().num_regions()");
+    }
+
+    fn find_region(&self, _addr: GuestAddress) -> Option<&Self::R> {
+        panic!("please use GuestMemoryMmapAtomic::snapshot().find_region(addr)");
+    }
+
+    fn with_regions<F, E>(&self, cb: F) -> result::Result<(), E>
+    where
+        F: Fn(usize, &Self::R) -> result::Result<(), E>,
+    {
+        match self.inner {
+            Either::Object(ref o) => o.load().with_regions(cb),
+            Either::Guard(ref g) => g.with_regions(cb),
+        }
+    }
+
+    fn with_regions_mut<F, E>(&self, cb: F) -> result::Result<(), E>
+    where
+        F: FnMut(usize, &Self::R) -> result::Result<(), E>,
+    {
+        match self.inner {
+            Either::Object(ref o) => o.load().with_regions_mut(cb),
+            Either::Guard(ref g) => g.with_regions_mut(cb),
+        }
+    }
+
+    fn map_and_fold<F, G, T>(&self, init: T, mapf: F, foldf: G) -> T
+    where
+        F: Fn((usize, &Self::R)) -> T,
+        G: Fn(T, T) -> T,
+    {
+        match self.inner {
+            Either::Object(ref o) => o.load().map_and_fold(init, mapf, foldf),
+            Either::Guard(ref g) => g.map_and_fold(init, mapf, foldf),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{guest_memory, GuestMemoryRegion, GuestUsize};
+
+    #[test]
+    fn test_snapshot() {
+        let region_size = 0x400;
+        let regions = vec![
+            (GuestAddress(0x0), region_size),
+            (GuestAddress(0x1000), region_size),
+        ];
+        let mut iterated_regions = Vec::new();
+        let gm = GuestMemoryMmapAtomic::new(&regions).unwrap();
+        let snapshot = gm.snapshot();
+
+        let res: guest_memory::Result<()> = snapshot.with_regions(|_, region| {
+            assert_eq!(region.len(), region_size as GuestUsize);
+            Ok(())
+        });
+        assert!(res.is_ok());
+        let res: guest_memory::Result<()> = snapshot.with_regions_mut(|_, region| {
+            iterated_regions.push((region.start_addr(), region.len() as usize));
+            Ok(())
+        });
+        assert!(res.is_ok());
+        assert_eq!(regions, iterated_regions);
+
+        assert!(regions
+            .iter()
+            .map(|x| (x.0, x.1))
+            .eq(iterated_regions.iter().map(|x| *x)));
+    }
+
+    #[should_panic]
+    #[test]
+    fn test_num_regions_panic() {
+        let region_size = 0x400;
+        let regions = vec![
+            (GuestAddress(0x0), region_size),
+            (GuestAddress(0x1000), region_size),
+        ];
+        let gm = GuestMemoryMmapAtomic::new(&regions).unwrap();
+        let _ = gm.num_regions();
+    }
+
+    #[should_panic]
+    #[test]
+    fn test_find_region_panic() {
+        let region_size = 0x400;
+        let regions = vec![
+            (GuestAddress(0x0), region_size),
+            (GuestAddress(0x1000), region_size),
+        ];
+        let gm = GuestMemoryMmapAtomic::new(&regions).unwrap();
+        let _ = gm.find_region(GuestAddress(0x1001));
+    }
+}


### PR DESCRIPTION
As discussed in the thread, https://github.com/rust-vmm/vm-memory/pull/43
ArcSwap is suggested to provide RCU-like protection for GuestMemoryMmap to support guest memory hotplug.
    
Intel Cloud Hypervisor has an implementation based on ArcSwap to support memory hotplug:
    https://github.com/cloud-hypervisor/cloud-hypervisor/pull/572
But the implementation touches too much files and makes it's hard to reuse code. So this patch extends the vm-memory crate to support both memory hotplug and code reuse.
