### PR TITLE
Add dirty page tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 ## [Unreleased]
 
+### Added
+
+  - [[#125]](https://github.com/rust-vmm/vm-memory/pull/125): Add dirty bitmap tracking abstractions. 
+
 ### Deprecated 
 
   - [[#133]](https://github.com/rust-vmm/vm-memory/issues/8): Deprecate `GuestMemory::with_regions()`,
-   `GuestMemory::with_regions_mut()`, `GuestMemory::map_and_fold()`
+   `GuestMemory::with_regions_mut()`, `GuestMemory::map_and_fold()`.
 
 ## [v0.5.0]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ arc-swap = { version = ">=1.0.0", optional = true }
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = ">=0.3"
-features = ["errhandlingapi"]
+features = ["errhandlingapi", "sysinfoapi"]
 
 [dev-dependencies]
 criterion = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ autobenches = false
 
 [features]
 default = []
+backend-bitmap = []
 backend-mmap = []
 backend-atomic = ["arc-swap"]
 

--- a/benches/guest_memory.rs
+++ b/benches/guest_memory.rs
@@ -4,6 +4,8 @@
 #![cfg(feature = "backend-mmap")]
 
 pub use criterion::{black_box, Criterion};
+
+use vm_memory::bitmap::Bitmap;
 use vm_memory::{GuestAddress, GuestMemory, GuestMemoryMmap};
 
 const REGION_SIZE: usize = 0x10_0000;
@@ -13,7 +15,10 @@ pub fn benchmark_for_guest_memory(c: &mut Criterion) {
     benchmark_find_region(c);
 }
 
-fn find_region(mem: &GuestMemoryMmap) {
+fn find_region<B>(mem: &GuestMemoryMmap<B>)
+where
+    B: Bitmap + 'static,
+{
     for i in 0..REGIONS_COUNT {
         let _ = mem
             .find_region(black_box(GuestAddress(i * REGION_SIZE as u64)))

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -17,7 +17,7 @@ use volatile::benchmark_for_volatile;
 #[cfg(feature = "backend-mmap")]
 // Use this function with caution. It does not check against overflows
 // and `GuestMemoryMmap::from_ranges` errors.
-fn create_guest_memory_mmap(size: usize, count: u64) -> GuestMemoryMmap {
+fn create_guest_memory_mmap(size: usize, count: u64) -> GuestMemoryMmap<()> {
     let mut regions: Vec<(GuestAddress, usize)> = Vec::new();
     for i in 0..count {
         regions.push((GuestAddress(i * size as u64), size));

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 85.4,
+  "coverage_score": 87.0,
   "exclude_path": "mmap_windows.rs",
   "crate_features": "backend-mmap,backend-atomic"
 }

--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -142,11 +142,10 @@ impl<M: GuestMemory> GuestMemoryExclusiveGuard<'_, M> {
 #[cfg(feature = "backend-mmap")]
 mod tests {
     use super::*;
-    use crate::{
-        GuestAddress, GuestMemory, GuestMemoryMmap, GuestMemoryRegion, GuestRegionMmap, GuestUsize,
-        MmapRegion,
-    };
+    use crate::{GuestAddress, GuestMemory, GuestMemoryRegion, GuestUsize, MmapRegion};
 
+    type GuestMemoryMmap = crate::GuestMemoryMmap<()>;
+    type GuestRegionMmap = crate::GuestRegionMmap<()>;
     type GuestMemoryMmapAtomic = GuestMemoryAtomic<GuestMemoryMmap>;
 
     #[test]

--- a/src/bitmap/backend/atomic_bitmap.rs
+++ b/src/bitmap/backend/atomic_bitmap.rs
@@ -137,9 +137,12 @@ impl NewBitmap for AtomicBitmap {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
+    use crate::bitmap::tests::test_bitmap;
+
     #[test]
     fn bitmap_basic() {
-        use super::AtomicBitmap;
         let b = AtomicBitmap::new(1024, 128);
         assert_eq!(b.len(), 8);
         b.set_addr_range(128, 129);
@@ -161,12 +164,17 @@ mod tests {
 
     #[test]
     fn bitmap_out_of_range() {
-        use super::AtomicBitmap;
         let b = AtomicBitmap::new(1024, 128);
         // Set a partial range that goes beyond the end of the bitmap
         b.set_addr_range(768, 512);
         assert!(b.is_addr_set(768));
         // The bitmap is never set beyond its end
         assert!(!b.is_addr_set(1152));
+    }
+
+    #[test]
+    fn test_bitmap_impl() {
+        let b = AtomicBitmap::new(0x2000, 128);
+        test_bitmap(&b);
     }
 }

--- a/src/bitmap/backend/atomic_bitmap.rs
+++ b/src/bitmap/backend/atomic_bitmap.rs
@@ -74,6 +74,14 @@ impl AtomicBitmap {
         self.size
     }
 
+    /// Get the bitmap of pages dirtied, and reset the bitmap inside `AtomicBitmap` (atomically across 64 pages)
+    pub fn get_and_reset(&self) -> Vec<u64> {
+        self.map
+            .iter()
+            .map(|u| u.fetch_and(0, Ordering::SeqCst))
+            .collect()
+    }
+
     /// Reset all bitmap bits to 0.
     pub fn reset(&self) {
         for it in self.map.iter() {

--- a/src/bitmap/backend/atomic_bitmap.rs
+++ b/src/bitmap/backend/atomic_bitmap.rs
@@ -127,8 +127,28 @@ impl NewBitmap for AtomicBitmap {
     fn with_len(len: usize) -> Self {
         use std::convert::TryFrom;
 
-        // There's no unsafe potential in calling this function.
-        let page_size = unsafe { libc::sysconf(libc::_SC_PAGE_SIZE) };
+        let page_size;
+
+        #[cfg(unix)]
+        {
+            // There's no unsafe potential in calling this function.
+            page_size = unsafe { libc::sysconf(libc::_SC_PAGE_SIZE) };
+        }
+
+        #[cfg(windows)]
+        {
+            use winapi::um::sysinfoapi::{GetSystemInfo, LPSYSTEM_INFO, SYSTEM_INFO};
+
+            // It's safe to initialize this object from a zeroed memory region.
+            let mut sysinfo: SYSTEM_INFO = unsafe { std::mem::zeroed() };
+
+            // It's safe to call this method as the pointer is based on the address
+            // of the previously initialized `sysinfo` object.
+            unsafe { GetSystemInfo(&mut sysinfo as LPSYSTEM_INFO) };
+
+            page_size = sysinfo.dwPageSize;
+        }
+
         // The `unwrap` is safe to use because the above call should always succeed on the
         // supported platforms, and the size of a page will always fit within a `usize`.
         AtomicBitmap::new(len, usize::try_from(page_size).unwrap())

--- a/src/bitmap/backend/atomic_bitmap.rs
+++ b/src/bitmap/backend/atomic_bitmap.rs
@@ -1,0 +1,172 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+//! Bitmap backend implementation based on atomic integers.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::bitmap::{Bitmap, RefSlice, WithBitmapSlice};
+
+#[cfg(feature = "backend-mmap")]
+use crate::mmap::NewBitmap;
+
+/// `AtomicBitmap` implements a simple bit map on the page level with test and set operations.
+/// It is page-size aware, so it converts addresses to page numbers before setting or clearing
+/// the bits.
+#[derive(Debug)]
+pub struct AtomicBitmap {
+    map: Vec<AtomicU64>,
+    size: usize,
+    page_size: usize,
+}
+
+#[allow(clippy::len_without_is_empty)]
+impl AtomicBitmap {
+    /// Create a new bitmap of `byte_size`, with one bit per `page_size`.
+    /// In reality this is rounded up, and you get a new vector of the next multiple of 64 bigger
+    /// than `size` for free.
+    pub fn new(byte_size: usize, page_size: usize) -> Self {
+        // Bit size is the number of bits in the bitmap, always at least 1 (to store the state of
+        // the '0' address).
+        let bit_size = std::cmp::max(1, byte_size / page_size);
+        // Create the map of `AtomicU64`, allowing the bit set operations to be done on a non-mut
+        // `Bitmap`, avoiding the need for a Mutex or other serialization.
+        let map_size = ((bit_size - 1) >> 6) + 1;
+        let map: Vec<AtomicU64> = (0..map_size).map(|_| AtomicU64::new(0)).collect();
+
+        AtomicBitmap {
+            map,
+            size: bit_size,
+            page_size,
+        }
+    }
+
+    /// Is bit `n` set? Bits outside the range of the bitmap are always unset.
+    pub fn is_bit_set(&self, n: usize) -> bool {
+        if n <= self.size {
+            (self.map[n >> 6].load(Ordering::Acquire) & (1 << (n & 63))) != 0
+        } else {
+            // Out-of-range bits are always unset.
+            false
+        }
+    }
+
+    /// Is the bit corresponding to address `addr` set?
+    pub fn is_addr_set(&self, addr: usize) -> bool {
+        self.is_bit_set(addr / self.page_size)
+    }
+
+    /// Set a range of bits starting at `start_addr` and continuing for the next `len` bytes.
+    pub fn set_addr_range(&self, start_addr: usize, len: usize) {
+        let first_bit = start_addr / self.page_size;
+        let page_count = (len + self.page_size - 1) / self.page_size;
+        for n in first_bit..(first_bit + page_count) {
+            if n > self.size {
+                // Attempts to set bits beyond the end of the bitmap are simply ignored.
+                break;
+            }
+            self.map[n >> 6].fetch_or(1 << (n & 63), Ordering::SeqCst);
+        }
+    }
+
+    /// Get the length of the bitmap in bits (i.e. in how many pages it can represent).
+    pub fn len(&self) -> usize {
+        self.size
+    }
+
+    /// Reset all bitmap bits to 0.
+    pub fn reset(&self) {
+        for it in self.map.iter() {
+            it.store(0, Ordering::Release);
+        }
+    }
+}
+
+impl Clone for AtomicBitmap {
+    fn clone(&self) -> Self {
+        let map = self
+            .map
+            .iter()
+            .map(|i| i.load(Ordering::Acquire))
+            .map(AtomicU64::new)
+            .collect();
+        AtomicBitmap {
+            map,
+            size: self.size,
+            page_size: self.page_size,
+        }
+    }
+}
+
+impl<'a> WithBitmapSlice<'a> for AtomicBitmap {
+    type S = RefSlice<'a, Self>;
+}
+
+impl Bitmap for AtomicBitmap {
+    fn mark_dirty(&self, offset: usize, len: usize) {
+        self.set_addr_range(offset, len)
+    }
+
+    fn dirty_at(&self, offset: usize) -> bool {
+        self.is_addr_set(offset)
+    }
+
+    fn slice_at(&self, offset: usize) -> <Self as WithBitmapSlice>::S {
+        RefSlice::new(self, offset)
+    }
+}
+
+impl Default for AtomicBitmap {
+    fn default() -> Self {
+        AtomicBitmap::new(0, 0x1000)
+    }
+}
+
+#[cfg(feature = "backend-mmap")]
+impl NewBitmap for AtomicBitmap {
+    fn with_len(len: usize) -> Self {
+        use std::convert::TryFrom;
+
+        // There's no unsafe potential in calling this function.
+        let page_size = unsafe { libc::sysconf(libc::_SC_PAGE_SIZE) };
+        // The `unwrap` is safe to use because the above call should always succeed on the
+        // supported platforms, and the size of a page will always fit within a `usize`.
+        AtomicBitmap::new(len, usize::try_from(page_size).unwrap())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn bitmap_basic() {
+        use super::AtomicBitmap;
+        let b = AtomicBitmap::new(1024, 128);
+        assert_eq!(b.len(), 8);
+        b.set_addr_range(128, 129);
+        assert!(!b.is_addr_set(0));
+        assert!(b.is_addr_set(128));
+        assert!(b.is_addr_set(256));
+        assert!(!b.is_addr_set(384));
+
+        #[allow(clippy::redundant_clone)]
+        let copy_b = b.clone();
+        assert!(copy_b.is_addr_set(256));
+        assert!(!copy_b.is_addr_set(384));
+
+        b.reset();
+        assert!(!b.is_addr_set(128));
+        assert!(!b.is_addr_set(256));
+        assert!(!b.is_addr_set(384));
+    }
+
+    #[test]
+    fn bitmap_out_of_range() {
+        use super::AtomicBitmap;
+        let b = AtomicBitmap::new(1024, 128);
+        // Set a partial range that goes beyond the end of the bitmap
+        b.set_addr_range(768, 512);
+        assert!(b.is_addr_set(768));
+        // The bitmap is never set beyond its end
+        assert!(!b.is_addr_set(1152));
+    }
+}

--- a/src/bitmap/backend/mod.rs
+++ b/src/bitmap/backend/mod.rs
@@ -1,0 +1,6 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+mod ref_slice;
+
+pub use ref_slice::RefSlice;

--- a/src/bitmap/backend/mod.rs
+++ b/src/bitmap/backend/mod.rs
@@ -1,6 +1,8 @@
 // Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
+mod atomic_bitmap;
 mod ref_slice;
 
+pub use atomic_bitmap::AtomicBitmap;
 pub use ref_slice::RefSlice;

--- a/src/bitmap/backend/ref_slice.rs
+++ b/src/bitmap/backend/ref_slice.rs
@@ -1,0 +1,74 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+//! Contains a generic implementation of `BitmapSlice`.
+
+use std::fmt::{self, Debug};
+
+use crate::bitmap::{Bitmap, BitmapSlice, WithBitmapSlice};
+
+/// Represents a slice into a `Bitmap` object, starting at `base_offset`.
+pub struct RefSlice<'a, B> {
+    inner: &'a B,
+    base_offset: usize,
+}
+
+impl<'a, B: Bitmap + 'a> RefSlice<'a, B> {
+    /// Create a new `BitmapSlice`, starting at the specified `offset`.
+    pub fn new(bitmap: &'a B, offset: usize) -> Self {
+        RefSlice {
+            inner: bitmap,
+            base_offset: offset,
+        }
+    }
+}
+
+impl<'a, B: Bitmap> WithBitmapSlice<'a> for RefSlice<'_, B> {
+    type S = Self;
+}
+
+impl<B: Bitmap> BitmapSlice for RefSlice<'_, B> {}
+
+impl<'a, B: Bitmap> Bitmap for RefSlice<'a, B> {
+    /// Mark the memory range specified by the given `offset` (relative to the base offset of
+    /// the slice) and `len` as dirtied.
+    fn mark_dirty(&self, offset: usize, len: usize) {
+        // The `Bitmap` operations are supposed to accompany guest memory accesses defined by the
+        // same parameters (i.e. offset & length), so we use simple wrapping arithmetic instead of
+        // performing additional checks. If an overflow would occur, we simply end up marking some
+        // other region as dirty (which is just a false positive) instead of a region that could
+        // not have been accessed to begin with.
+        self.inner
+            .mark_dirty(self.base_offset.wrapping_add(offset), len)
+    }
+
+    fn dirty_at(&self, offset: usize) -> bool {
+        self.inner.dirty_at(self.base_offset.wrapping_add(offset))
+    }
+
+    /// Create a new `BitmapSlice` starting from the specified `offset` into the current slice.
+    fn slice_at(&self, offset: usize) -> Self {
+        RefSlice {
+            inner: self.inner,
+            base_offset: self.base_offset.wrapping_add(offset),
+        }
+    }
+}
+
+impl<'a, B> Clone for RefSlice<'a, B> {
+    fn clone(&self) -> Self {
+        RefSlice {
+            inner: self.inner,
+            base_offset: self.base_offset,
+        }
+    }
+}
+
+impl<'a, B> Copy for RefSlice<'a, B> {}
+
+impl<'a, B> Debug for RefSlice<'a, B> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Dummy impl for now.
+        write!(f, "(bitmap slice)")
+    }
+}

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -6,9 +6,15 @@
 //! `GuestMemoryRegion` object, and the resulting bitmaps can then be aggregated to build the
 //! global view for an entire `GuestMemory` object.
 
+#[cfg(any(test, feature = "backend-bitmap"))]
+mod backend;
+
 use std::fmt::Debug;
 
 use crate::{GuestMemory, GuestMemoryRegion};
+
+#[cfg(any(test, feature = "backend-bitmap"))]
+pub use backend::RefSlice;
 
 /// Trait implemented by types that support creating `BitmapSlice` objects.
 pub trait WithBitmapSlice<'a> {

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -14,7 +14,7 @@ use std::fmt::Debug;
 use crate::{GuestMemory, GuestMemoryRegion};
 
 #[cfg(any(test, feature = "backend-bitmap"))]
-pub use backend::RefSlice;
+pub use backend::{AtomicBitmap, RefSlice};
 
 /// Trait implemented by types that support creating `BitmapSlice` objects.
 pub trait WithBitmapSlice<'a> {

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -108,3 +108,321 @@ pub type BS<'a, B> = <B as WithBitmapSlice<'a>>::S;
 /// Helper type alias for referring to the `BitmapSlice` concrete type associated with
 /// the memory regions of an object `M: GuestMemory`.
 pub type MS<'a, M> = BS<'a, <<M as GuestMemory>::R as GuestMemoryRegion>::B>;
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+
+    use std::io::Cursor;
+    use std::marker::PhantomData;
+    use std::mem::size_of_val;
+    use std::result::Result;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use crate::{Bytes, VolatileMemory};
+    #[cfg(feature = "backend-mmap")]
+    use crate::{GuestAddress, MemoryRegionAddress};
+
+    // Helper method to check whether a specified range is clean.
+    pub fn range_is_clean<B: Bitmap>(b: &B, start: usize, len: usize) -> bool {
+        (start..start + len).all(|offset| !b.dirty_at(offset))
+    }
+
+    // Helper method to check whether a specified range is dirty.
+    pub fn range_is_dirty<B: Bitmap>(b: &B, start: usize, len: usize) -> bool {
+        (start..start + len).all(|offset| b.dirty_at(offset))
+    }
+
+    pub fn check_range<B: Bitmap>(b: &B, start: usize, len: usize, clean: bool) -> bool {
+        if clean {
+            range_is_clean(b, start, len)
+        } else {
+            range_is_dirty(b, start, len)
+        }
+    }
+
+    // Helper method that tests a generic `B: Bitmap` implementation. It assumes `b` covers
+    // an area of length at least 0x2000.
+    pub fn test_bitmap<B: Bitmap>(b: &B) {
+        let len = 0x2000;
+        let dirty_offset = 0x1000;
+        let dirty_len = 0x100;
+
+        // Some basic checks.
+        let s = b.slice_at(dirty_offset);
+
+        assert!(range_is_clean(b, 0, len));
+        assert!(range_is_clean(&s, 0, dirty_len));
+
+        b.mark_dirty(dirty_offset, dirty_len);
+        assert!(range_is_dirty(b, dirty_offset, dirty_len));
+        assert!(range_is_dirty(&s, 0, dirty_len));
+    }
+
+    #[derive(Debug)]
+    pub enum TestAccessError {
+        RangeCleanCheck,
+        RangeDirtyCheck,
+    }
+
+    // A helper object that implements auxiliary operations for testing `Bytes` implementations
+    // in the context of dirty bitmap tracking.
+    struct BytesHelper<F, G, M> {
+        check_range_fn: F,
+        address_fn: G,
+        phantom: PhantomData<*const M>,
+    }
+
+    // `F` represents a closure the checks whether a specified range associated with the `Bytes`
+    // object that's being tested is marked as dirty or not (depending on the value of the last
+    // parameter). It has the following parameters:
+    // - A reference to a `Bytes` implementations that's subject to testing.
+    // - The offset of the range.
+    // - The length of the range.
+    // - Whether we are checking if the range is clean (when `true`) or marked as dirty.
+    //
+    // `G` represents a closure that translates an offset into an address value that's
+    // relevant for the `Bytes` implementation being tested.
+    impl<F, G, M, A> BytesHelper<F, G, M>
+    where
+        F: Fn(&M, usize, usize, bool) -> bool,
+        G: Fn(usize) -> A,
+        M: Bytes<A>,
+    {
+        fn check_range(&self, m: &M, start: usize, len: usize, clean: bool) -> bool {
+            (self.check_range_fn)(m, start, len, clean)
+        }
+
+        fn address(&self, offset: usize) -> A {
+            (self.address_fn)(offset)
+        }
+
+        fn test_access<Op>(
+            &self,
+            bytes: &M,
+            dirty_offset: usize,
+            dirty_len: usize,
+            op: Op,
+        ) -> Result<(), TestAccessError>
+        where
+            Op: Fn(&M, A),
+        {
+            if !self.check_range(bytes, dirty_offset, dirty_len, true) {
+                return Err(TestAccessError::RangeCleanCheck);
+            }
+
+            op(bytes, self.address(dirty_offset));
+
+            if !self.check_range(bytes, dirty_offset, dirty_len, false) {
+                return Err(TestAccessError::RangeDirtyCheck);
+            }
+
+            Ok(())
+        }
+    }
+
+    // `F` and `G` stand for the same closure types as described in the `BytesHelper` comment.
+    // The `step` parameter represents the offset that's added the the current address after
+    // performing each access. It provides finer grained control when testing tracking
+    // implementations that aggregate entire ranges for accounting purposes (for example, doing
+    // tracking at the page level).
+    pub fn test_bytes<F, G, M, A>(bytes: &M, check_range_fn: F, address_fn: G, step: usize)
+    where
+        F: Fn(&M, usize, usize, bool) -> bool,
+        G: Fn(usize) -> A,
+        A: Copy,
+        M: Bytes<A>,
+        <M as Bytes<A>>::E: Debug,
+    {
+        const BUF_SIZE: usize = 1024;
+        let buf = vec![1u8; 1024];
+
+        let val = 1u64;
+
+        let h = BytesHelper {
+            check_range_fn,
+            address_fn,
+            phantom: PhantomData,
+        };
+
+        let mut dirty_offset = 0x1000;
+
+        // Test `write`.
+        h.test_access(bytes, dirty_offset, BUF_SIZE, |m, addr| {
+            assert_eq!(m.write(buf.as_slice(), addr).unwrap(), BUF_SIZE)
+        })
+        .unwrap();
+        dirty_offset += step;
+
+        // Test `write_slice`.
+        h.test_access(bytes, dirty_offset, BUF_SIZE, |m, addr| {
+            m.write_slice(buf.as_slice(), addr).unwrap()
+        })
+        .unwrap();
+        dirty_offset += step;
+
+        // Test `write_obj`.
+        h.test_access(bytes, dirty_offset, size_of_val(&val), |m, addr| {
+            m.write_obj(val, addr).unwrap()
+        })
+        .unwrap();
+        dirty_offset += step;
+
+        // Test `read_from`.
+        h.test_access(bytes, dirty_offset, BUF_SIZE, |m, addr| {
+            assert_eq!(
+                m.read_from(addr, &mut Cursor::new(&buf), BUF_SIZE).unwrap(),
+                BUF_SIZE
+            )
+        })
+        .unwrap();
+        dirty_offset += step;
+
+        // Test `read_exact_from`.
+        h.test_access(bytes, dirty_offset, BUF_SIZE, |m, addr| {
+            m.read_exact_from(addr, &mut Cursor::new(&buf), BUF_SIZE)
+                .unwrap()
+        })
+        .unwrap();
+        dirty_offset += step;
+
+        // Test `store`.
+        h.test_access(bytes, dirty_offset, size_of_val(&val), |m, addr| {
+            m.store(val, addr, Ordering::Relaxed).unwrap()
+        })
+        .unwrap();
+    }
+
+    // This function and the next are currently conditionally compiled because we only use
+    // them to test the mmap-based backend implementations for now. Going forward, the generic
+    // test functions defined here can be placed in a separate module (i.e. `test_utilities`)
+    // which is gated by a feature and can be used for testing purposes by other crates as well.
+    #[cfg(feature = "backend-mmap")]
+    fn test_guest_memory_region<R: GuestMemoryRegion>(region: &R) {
+        let dirty_addr = MemoryRegionAddress(0x0);
+        let val = 123u64;
+        let dirty_len = size_of_val(&val);
+
+        let slice = region.get_slice(dirty_addr, dirty_len).unwrap();
+
+        assert!(range_is_clean(region.bitmap(), 0, region.len() as usize));
+        assert!(range_is_clean(slice.bitmap(), 0, dirty_len));
+
+        region.write_obj(val, dirty_addr).unwrap();
+
+        assert!(range_is_dirty(
+            region.bitmap(),
+            dirty_addr.0 as usize,
+            dirty_len
+        ));
+
+        assert!(range_is_dirty(slice.bitmap(), 0, dirty_len));
+
+        // Finally, let's invoke the generic tests for `R: Bytes`. It's ok to pass the same
+        // `region` handle because `test_bytes` starts performing writes after the range that's
+        // been already dirtied in the first part of this test.
+        test_bytes(
+            region,
+            |r: &R, start: usize, len: usize, clean: bool| {
+                check_range(r.bitmap(), start, len, clean)
+            },
+            |offset| MemoryRegionAddress(offset as u64),
+            0x1000,
+        );
+    }
+
+    #[cfg(feature = "backend-mmap")]
+    // Assumptions about M generated by f ...
+    pub fn test_guest_memory_and_region<M, F>(f: F)
+    where
+        M: GuestMemory,
+        F: Fn() -> M,
+    {
+        let m = f();
+        let dirty_addr = GuestAddress(0x1000);
+        let val = 123u64;
+        let dirty_len = size_of_val(&val);
+
+        let (region, region_addr) = m.to_region_addr(dirty_addr).unwrap();
+        let slice = m.get_slice(dirty_addr, dirty_len).unwrap();
+
+        assert!(range_is_clean(region.bitmap(), 0, region.len() as usize));
+        assert!(range_is_clean(slice.bitmap(), 0, dirty_len));
+
+        m.write_obj(val, dirty_addr).unwrap();
+
+        assert!(range_is_dirty(
+            region.bitmap(),
+            region_addr.0 as usize,
+            dirty_len
+        ));
+
+        assert!(range_is_dirty(slice.bitmap(), 0, dirty_len));
+
+        // Now let's invoke the tests for the inner `GuestMemoryRegion` type.
+        test_guest_memory_region(f().find_region(GuestAddress(0)).unwrap());
+
+        // Finally, let's invoke the generic tests for `Bytes`.
+        let check_range_closure = |m: &M, start: usize, len: usize, clean: bool| -> bool {
+            let mut check_result = true;
+            m.try_access(len, GuestAddress(start as u64), |_, size, reg_addr, reg| {
+                if !check_range(reg.bitmap(), reg_addr.0 as usize, size, clean) {
+                    check_result = false;
+                }
+                Ok(size)
+            })
+            .unwrap();
+
+            check_result
+        };
+
+        test_bytes(
+            &f(),
+            check_range_closure,
+            |offset| GuestAddress(offset as u64),
+            0x1000,
+        );
+    }
+
+    pub fn test_volatile_memory<M: VolatileMemory>(m: &M) {
+        assert!(m.len() >= 0x8000);
+
+        let dirty_offset = 0x1000;
+        let val = 123u64;
+        let dirty_len = size_of_val(&val);
+
+        let get_ref_offset = 0x2000;
+        let array_ref_offset = 0x3000;
+        let align_as_mut_offset = 0x4000;
+        let atomic_ref_offset = 0x5000;
+
+        let s1 = m.as_volatile_slice();
+        let s2 = m.get_slice(dirty_offset, dirty_len).unwrap();
+
+        assert!(range_is_clean(s1.bitmap(), 0, s1.len()));
+        assert!(range_is_clean(s2.bitmap(), 0, s2.len()));
+
+        s1.write_obj(val, dirty_offset).unwrap();
+
+        assert!(range_is_dirty(s1.bitmap(), dirty_offset, dirty_len));
+        assert!(range_is_dirty(s2.bitmap(), 0, dirty_len));
+
+        let v_ref = m.get_ref::<u64>(get_ref_offset).unwrap();
+        assert!(range_is_clean(s1.bitmap(), get_ref_offset, dirty_len));
+        v_ref.store(val);
+        assert!(range_is_dirty(s1.bitmap(), get_ref_offset, dirty_len));
+
+        let arr_ref = m.get_array_ref::<u64>(array_ref_offset, 1).unwrap();
+        assert!(range_is_clean(s1.bitmap(), array_ref_offset, dirty_len));
+        arr_ref.store(0, val);
+        assert!(range_is_dirty(s1.bitmap(), array_ref_offset, dirty_len));
+
+        assert!(range_is_clean(s1.bitmap(), align_as_mut_offset, dirty_len));
+        unsafe { m.aligned_as_mut::<u64>(align_as_mut_offset) }.unwrap();
+        assert!(range_is_dirty(s1.bitmap(), align_as_mut_offset, dirty_len));
+
+        assert!(range_is_clean(s1.bitmap(), atomic_ref_offset, dirty_len));
+        m.get_atomic_ref::<AtomicU64>(atomic_ref_offset).unwrap();
+        assert!(range_is_dirty(s1.bitmap(), atomic_ref_offset, dirty_len));
+    }
+}

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -1,0 +1,104 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+//! This module holds abstractions that enable tracking the areas dirtied by writes of a specified
+//! length to a given offset. In particular, this is used to track write accesses within a
+//! `GuestMemoryRegion` object, and the resulting bitmaps can then be aggregated to build the
+//! global view for an entire `GuestMemory` object.
+
+use std::fmt::Debug;
+
+use crate::{GuestMemory, GuestMemoryRegion};
+
+/// Trait implemented by types that support creating `BitmapSlice` objects.
+pub trait WithBitmapSlice<'a> {
+    /// Type of the bitmap slice.
+    type S: BitmapSlice;
+}
+
+/// Trait used to represent that a `BitmapSlice` is a `Bitmap` itself, but also satisfies the
+/// restriction that slices created from it have the same type as `Self`.
+pub trait BitmapSlice:
+    Bitmap + Clone + Copy + Debug + for<'a> WithBitmapSlice<'a, S = Self>
+{
+}
+
+/// Common bitmap operations. Using Higher-Rank Trait Bounds (HRTBs) to effectively define
+/// an associated type that has a lifetime parameter, without tagging the `Bitmap` trait with
+/// a lifetime as well.
+///
+/// Using an associated type allows implementing the `Bitmap` and `BitmapSlice` functionality
+/// as a zero-cost abstraction when providing trivial implementations such as the one
+/// defined for `()`.
+// These methods represent the core functionality that's required by `vm-memory` abstractions
+// to implement generic tracking logic, as well as tests that can be reused by different backends.
+pub trait Bitmap: for<'a> WithBitmapSlice<'a> {
+    /// Mark the memory range specified by the given `offset` and `len` as dirtied.
+    fn mark_dirty(&self, offset: usize, len: usize);
+
+    /// Check whether the specified `offset` is marked as dirty.
+    fn dirty_at(&self, offset: usize) -> bool;
+
+    /// Return a `Self::S::Slice` of the current bitmap, starting at the specified `offset`.
+    fn slice_at(&self, offset: usize) -> <Self as WithBitmapSlice>::S;
+}
+
+/// A no-op `Bitmap` implementation that can be provided for backends that do not actually
+/// require the tracking functionality.
+
+impl<'a> WithBitmapSlice<'a> for () {
+    type S = Self;
+}
+
+impl BitmapSlice for () {}
+
+impl Bitmap for () {
+    fn mark_dirty(&self, _offset: usize, _len: usize) {}
+
+    fn dirty_at(&self, _offset: usize) -> bool {
+        false
+    }
+
+    fn slice_at(&self, _offset: usize) -> Self {}
+}
+
+/// A `Bitmap` and `BitmapSlice` implementation for `Option<B>`.
+
+impl<'a, B> WithBitmapSlice<'a> for Option<B>
+where
+    B: WithBitmapSlice<'a>,
+{
+    type S = Option<B::S>;
+}
+
+impl<B: BitmapSlice> BitmapSlice for Option<B> {}
+
+impl<B: Bitmap> Bitmap for Option<B> {
+    fn mark_dirty(&self, offset: usize, len: usize) {
+        if let Some(inner) = self {
+            inner.mark_dirty(offset, len)
+        }
+    }
+
+    fn dirty_at(&self, offset: usize) -> bool {
+        if let Some(inner) = self {
+            return inner.dirty_at(offset);
+        }
+        false
+    }
+
+    fn slice_at(&self, offset: usize) -> Option<<B as WithBitmapSlice>::S> {
+        if let Some(inner) = self {
+            return Some(inner.slice_at(offset));
+        }
+        None
+    }
+}
+
+/// Helper type alias for referring to the `BitmapSlice` concrete type associated with
+/// an object `B: WithBitmapSlice<'a>`.
+pub type BS<'a, B> = <B as WithBitmapSlice<'a>>::S;
+
+/// Helper type alias for referring to the `BitmapSlice` concrete type associated with
+/// the memory regions of an object `M: GuestMemory`.
+pub type MS<'a, M> = BS<'a, <<M as GuestMemory>::R as GuestMemoryRegion>::B>;

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -18,7 +18,7 @@ use std::slice::{from_raw_parts, from_raw_parts_mut};
 use std::sync::atomic::Ordering;
 
 use crate::atomic_integer::AtomicInteger;
-use crate::VolatileSlice;
+use crate::volatile_memory::VolatileSlice;
 
 /// Types for which it is safe to initialize from raw data.
 ///
@@ -115,10 +115,10 @@ pub unsafe trait ByteValued: Copy + Default + Send + Sync {
     /// reference to `self`; this trivially fulfills `VolatileSlice::new`'s requirement
     /// that all accesses to `self` use volatile accesses (because there can
     /// be no other accesses).
-    fn as_bytes(&mut self) -> VolatileSlice {
+    fn as_bytes(&mut self) -> VolatileSlice<()> {
         unsafe {
             // This is safe because the lifetime is the same as self
-            VolatileSlice::new(self as *mut Self as usize as *mut _, size_of::<Self>())
+            VolatileSlice::new(self as *mut Self as usize as *mut _, size_of::<Self>(), ())
         }
     }
 }

--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -43,8 +43,9 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use crate::address::{Address, AddressValue};
+use crate::bitmap::{Bitmap, BS, MS};
 use crate::bytes::{AtomicAccess, Bytes};
-use crate::volatile_memory;
+use crate::volatile_memory::{self, VolatileSlice};
 
 static MAX_ACCESS_CHUNK: usize = 4096;
 
@@ -165,6 +166,9 @@ impl FileOffset {
 /// Represents a continuous region of guest physical memory.
 #[allow(clippy::len_without_is_empty)]
 pub trait GuestMemoryRegion: Bytes<MemoryRegionAddress, E = Error> {
+    /// Type used for dirty memory tracking.
+    type B: Bitmap;
+
     /// Returns the size of the region.
     fn len(&self) -> GuestUsize;
 
@@ -176,6 +180,9 @@ pub trait GuestMemoryRegion: Bytes<MemoryRegionAddress, E = Error> {
         // unchecked_add is safe as the region bounds were checked when it was created.
         self.start_addr().unchecked_add(self.len() - 1)
     }
+
+    /// Borrow the associated `Bitmap` object.
+    fn bitmap(&self) -> &Self::B;
 
     /// Returns the given address if it is within this region.
     fn check_address(&self, addr: MemoryRegionAddress) -> Option<MemoryRegionAddress> {
@@ -245,7 +252,9 @@ pub trait GuestMemoryRegion: Bytes<MemoryRegionAddress, E = Error> {
     ///
     /// # Safety
     ///
-    /// Unsafe because of possible aliasing.
+    /// Unsafe because of possible aliasing. Mutable accesses performed through the
+    /// returned slice are not visible to the dirty bitmap tracking functionality of
+    /// the region, and must be manually recorded using the associated bitmap object.
     unsafe fn as_mut_slice(&self) -> Option<&mut [u8]> {
         None
     }
@@ -257,7 +266,7 @@ pub trait GuestMemoryRegion: Bytes<MemoryRegionAddress, E = Error> {
         &self,
         offset: MemoryRegionAddress,
         count: usize,
-    ) -> Result<volatile_memory::VolatileSlice> {
+    ) -> Result<VolatileSlice<BS<Self::B>>> {
         Err(Error::HostAddressNotAvailable)
     }
 
@@ -286,7 +295,7 @@ pub trait GuestMemoryRegion: Bytes<MemoryRegionAddress, E = Error> {
     /// assert_eq!(r.load(), v);
     /// # }
     /// ```
-    fn as_volatile_slice(&self) -> Result<volatile_memory::VolatileSlice> {
+    fn as_volatile_slice(&self) -> Result<VolatileSlice<BS<Self::B>>> {
         self.get_slice(MemoryRegionAddress(0), self.len() as usize)
     }
 
@@ -386,8 +395,8 @@ pub trait GuestAddressSpace {
 }
 
 impl<M: GuestMemory> GuestAddressSpace for &M {
-    type T = Self;
     type M = M;
+    type T = Self;
 
     fn memory(&self) -> Self {
         self
@@ -395,8 +404,8 @@ impl<M: GuestMemory> GuestAddressSpace for &M {
 }
 
 impl<M: GuestMemory> GuestAddressSpace for Rc<M> {
-    type T = Self;
     type M = M;
+    type T = Self;
 
     fn memory(&self) -> Self {
         self.clone()
@@ -404,8 +413,8 @@ impl<M: GuestMemory> GuestAddressSpace for Rc<M> {
 }
 
 impl<M: GuestMemory> GuestAddressSpace for Arc<M> {
-    type T = Self;
     type M = M;
+    type T = Self;
 
     fn memory(&self) -> Self {
         self.clone()
@@ -705,11 +714,7 @@ pub trait GuestMemory {
 
     /// Returns a [`VolatileSlice`](struct.VolatileSlice.html) of `count` bytes starting at
     /// `addr`.
-    fn get_slice(
-        &self,
-        addr: GuestAddress,
-        count: usize,
-    ) -> Result<volatile_memory::VolatileSlice> {
+    fn get_slice(&self, addr: GuestAddress, count: usize) -> Result<VolatileSlice<MS<Self>>> {
         self.to_region_addr(addr)
             .ok_or(Error::InvalidGuestAddress(addr))
             .and_then(|(r, addr)| r.get_slice(addr, count))
@@ -836,16 +841,20 @@ impl<T: GuestMemory> Bytes<GuestAddress> for T {
             // Check if something bad happened before doing unsafe things.
             assert!(offset <= count);
             if let Some(dst) = unsafe { region.as_mut_slice() } {
-                // This is safe cause `start` and `len` are within the `region`.
+                // This is safe cause `start` and `len` are within the `region`, and we manually
+                // record the dirty status of the written range below.
                 let start = caddr.raw_value() as usize;
                 let end = start + len;
-                loop {
+                let result = loop {
                     match src.read(&mut dst[start..end]) {
                         Ok(n) => break Ok(n),
                         Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
                         Err(e) => break Err(Error::IOError(e)),
                     }
-                }
+                };
+
+                region.bitmap().mark_dirty(start, len);
+                result
             } else {
                 let len = std::cmp::min(len, MAX_ACCESS_CHUNK);
                 let mut buf = vec![0u8; len].into_boxed_slice();
@@ -1008,13 +1017,16 @@ mod tests {
     #[cfg(feature = "backend-mmap")]
     use crate::bytes::ByteValued;
     #[cfg(feature = "backend-mmap")]
-    use crate::{GuestAddress, GuestMemoryMmap};
+    use crate::GuestAddress;
     #[cfg(feature = "backend-mmap")]
     use std::io::Cursor;
     #[cfg(feature = "backend-mmap")]
     use std::time::{Duration, Instant};
 
     use vmm_sys_util::tempfile::TempFile;
+
+    #[cfg(feature = "backend-mmap")]
+    type GuestMemoryMmap = crate::GuestMemoryMmap<()>;
 
     #[cfg(feature = "backend-mmap")]
     fn make_image(size: u8) -> Vec<u8> {

--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -280,7 +280,7 @@ pub trait GuestMemoryRegion: Bytes<MemoryRegionAddress, E = Error> {
     /// # use vm_memory::{GuestAddress, MmapRegion, GuestRegionMmap, GuestMemoryRegion};
     /// # use vm_memory::volatile_memory::{VolatileMemory, VolatileSlice, VolatileRef};
     /// #
-    /// let region = MmapRegion::new(0x400).expect("Could not create mmap region");
+    /// let region = MmapRegion::<()>::new(0x400).expect("Could not create mmap region");
     /// let region =
     ///     GuestRegionMmap::new(region, GuestAddress(0x0)).expect("Could not create guest memory");
     /// let slice = region
@@ -310,7 +310,7 @@ pub trait GuestMemoryRegion: Bytes<MemoryRegionAddress, E = Error> {
     /// # {
     /// #   use vm_memory::{GuestAddress, GuestMemory, GuestMemoryMmap, GuestRegionMmap};
     /// let addr = GuestAddress(0x1000);
-    /// let mem = GuestMemoryMmap::from_ranges(&[(addr, 0x1000)]).unwrap();
+    /// let mem = GuestMemoryMmap::<()>::from_ranges(&[(addr, 0x1000)]).unwrap();
     /// let r = mem.find_region(addr).unwrap();
     /// assert_eq!(r.is_hugetlbfs(), None);
     /// # }
@@ -354,27 +354,27 @@ pub trait GuestMemoryRegion: Bytes<MemoryRegionAddress, E = Error> {
 ///     }
 /// }
 ///
-/// fn get_mmap() -> GuestMemoryMmap {
+/// fn get_mmap() -> GuestMemoryMmap<()> {
 ///     let start_addr = GuestAddress(0x1000);
 ///     GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x400)])
 ///         .expect("Could not create guest memory")
 /// }
 ///
 /// // Using `VirtioDevice` with an immutable GuestMemoryMmap:
-/// let mut for_immutable_mmap = VirtioDevice::<&GuestMemoryMmap>::new();
+/// let mut for_immutable_mmap = VirtioDevice::<&GuestMemoryMmap<()>>::new();
 /// let mmap = get_mmap();
 /// for_immutable_mmap.activate(&mmap);
-/// let mut another = VirtioDevice::<&GuestMemoryMmap>::new();
+/// let mut another = VirtioDevice::<&GuestMemoryMmap<()>>::new();
 /// another.activate(&mmap);
 ///
 /// # #[cfg(feature = "backend-atomic")]
 /// # {
 /// # use vm_memory::GuestMemoryAtomic;
 /// // Using `VirtioDevice` with a mutable GuestMemoryMmap:
-/// let mut for_mutable_mmap = VirtioDevice::<GuestMemoryAtomic<GuestMemoryMmap>>::new();
+/// let mut for_mutable_mmap = VirtioDevice::<GuestMemoryAtomic<GuestMemoryMmap<()>>>::new();
 /// let atomic = GuestMemoryAtomic::new(get_mmap());
 /// for_mutable_mmap.activate(atomic.clone());
-/// let mut another = VirtioDevice::<GuestMemoryAtomic<GuestMemoryMmap>>::new();
+/// let mut another = VirtioDevice::<GuestMemoryAtomic<GuestMemoryMmap<()>>>::new();
 /// another.activate(atomic.clone());
 ///
 /// // atomic can be modified here...
@@ -522,7 +522,7 @@ pub trait GuestMemory {
     /// #
     /// let start_addr1 = GuestAddress(0x0);
     /// let start_addr2 = GuestAddress(0x400);
-    /// let gm = GuestMemoryMmap::from_ranges(&vec![(start_addr1, 1024), (start_addr2, 2048)])
+    /// let gm = GuestMemoryMmap::<()>::from_ranges(&vec![(start_addr1, 1024), (start_addr2, 2048)])
     ///     .expect("Could not create guest memory");
     ///
     /// let total_size = gm
@@ -558,7 +558,7 @@ pub trait GuestMemory {
     /// #
     /// let start_addr1 = GuestAddress(0x0);
     /// let start_addr2 = GuestAddress(0x400);
-    /// let gm = GuestMemoryMmap::from_ranges(&vec![(start_addr1, 1024), (start_addr2, 2048)])
+    /// let gm = GuestMemoryMmap::<()>::from_ranges(&vec![(start_addr1, 1024), (start_addr2, 2048)])
     ///     .expect("Could not create guest memory");
     ///
     /// let total_size = gm.map_and_fold(0, |(_, region)| region.len() / 1024, |acc, size| acc + size);
@@ -585,7 +585,7 @@ pub trait GuestMemory {
     /// # use vm_memory::{Address, GuestAddress, GuestMemory, GuestMemoryMmap};
     /// #
     /// let start_addr = GuestAddress(0x1000);
-    /// let mut gm = GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x400)])
+    /// let mut gm = GuestMemoryMmap::<()>::from_ranges(&vec![(start_addr, 0x400)])
     ///     .expect("Could not create guest memory");
     ///
     /// assert_eq!(start_addr.checked_add(0x3ff), Some(gm.last_addr()));
@@ -697,7 +697,7 @@ pub trait GuestMemory {
     /// # use vm_memory::{GuestAddress, GuestMemory, GuestMemoryMmap};
     /// #
     /// # let start_addr = GuestAddress(0x1000);
-    /// # let mut gm = GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x500)])
+    /// # let mut gm = GuestMemoryMmap::<()>::from_ranges(&vec![(start_addr, 0x500)])
     /// #    .expect("Could not create guest memory");
     /// #
     /// let addr = gm
@@ -754,7 +754,7 @@ impl<T: GuestMemory> Bytes<GuestAddress> for T {
     /// # use vm_memory::{Bytes, GuestAddress, mmap::GuestMemoryMmap};
     /// #
     /// # let start_addr = GuestAddress(0x1000);
-    /// # let mut gm = GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x400)])
+    /// # let mut gm = GuestMemoryMmap::<()>::from_ranges(&vec![(start_addr, 0x400)])
     /// #    .expect("Could not create guest memory");
     /// #
     /// gm.write_slice(&[1, 2, 3, 4, 5], start_addr)
@@ -782,7 +782,7 @@ impl<T: GuestMemory> Bytes<GuestAddress> for T {
     /// # use vm_memory::{Bytes, GuestAddress, mmap::GuestMemoryMmap};
     /// #
     /// let start_addr = GuestAddress(0x1000);
-    /// let mut gm = GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x400)])
+    /// let mut gm = GuestMemoryMmap::<()>::from_ranges(&vec![(start_addr, 0x400)])
     ///     .expect("Could not create guest memory");
     /// let buf = &mut [0u8; 16];
     ///
@@ -813,7 +813,7 @@ impl<T: GuestMemory> Bytes<GuestAddress> for T {
     /// # use std::path::Path;
     /// #
     /// # let start_addr = GuestAddress(0x1000);
-    /// # let gm = GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x400)])
+    /// # let gm = GuestMemoryMmap::<()>::from_ranges(&vec![(start_addr, 0x400)])
     /// #    .expect("Could not create guest memory");
     /// # let addr = GuestAddress(0x1010);
     /// # let mut file = if cfg!(unix) {
@@ -899,7 +899,7 @@ impl<T: GuestMemory> Bytes<GuestAddress> for T {
     /// # use vm_memory::{Bytes, GuestAddress, GuestMemoryMmap};
     /// #
     /// # let start_addr = GuestAddress(0x1000);
-    /// # let gm = GuestMemoryMmap::from_ranges(&vec![(start_addr, 1024)])
+    /// # let gm = GuestMemoryMmap::<()>::from_ranges(&vec![(start_addr, 1024)])
     /// #    .expect("Could not create guest memory");
     /// # let mut file = if cfg!(unix) {
     /// # use std::fs::OpenOptions;
@@ -964,7 +964,7 @@ impl<T: GuestMemory> Bytes<GuestAddress> for T {
     /// # use vm_memory::{Bytes, GuestAddress, GuestMemoryMmap};
     /// #
     /// # let start_addr = GuestAddress(0x1000);
-    /// # let gm = GuestMemoryMmap::from_ranges(&vec![(start_addr, 1024)])
+    /// # let gm = GuestMemoryMmap::<()>::from_ranges(&vec![(start_addr, 1024)])
     /// #    .expect("Could not create guest memory");
     /// # let mut file = if cfg!(unix) {
     /// # use std::fs::OpenOptions;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,8 @@ pub use atomic::{GuestMemoryAtomic, GuestMemoryLoadGuard};
 mod atomic_integer;
 pub use atomic_integer::AtomicInteger;
 
+pub mod bitmap;
+
 pub mod bytes;
 pub use bytes::{AtomicAccess, ByteValued, Bytes};
 

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -175,7 +175,7 @@ impl<B: Bitmap> Bytes<MemoryRegionAddress> for GuestRegionMmap<B> {
     /// # use vm_memory::{Bytes, GuestAddress, GuestMemoryMmap};
     /// #
     /// # let start_addr = GuestAddress(0x1000);
-    /// # let mut gm = GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x400)])
+    /// # let mut gm = GuestMemoryMmap::<()>::from_ranges(&vec![(start_addr, 0x400)])
     /// #    .expect("Could not create guest memory");
     /// #
     /// let res = gm
@@ -198,7 +198,7 @@ impl<B: Bitmap> Bytes<MemoryRegionAddress> for GuestRegionMmap<B> {
     /// # use vm_memory::{Bytes, GuestAddress, GuestMemoryMmap};
     /// #
     /// # let start_addr = GuestAddress(0x1000);
-    /// # let mut gm = GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x400)])
+    /// # let mut gm = GuestMemoryMmap::<()>::from_ranges(&vec![(start_addr, 0x400)])
     /// #    .expect("Could not create guest memory");
     /// #
     /// let buf = &mut [0u8; 16];
@@ -241,7 +241,7 @@ impl<B: Bitmap> Bytes<MemoryRegionAddress> for GuestRegionMmap<B> {
     /// # use std::path::Path;
     /// #
     /// # let start_addr = GuestAddress(0x1000);
-    /// # let gm = GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x400)])
+    /// # let gm = GuestMemoryMmap::<()>::from_ranges(&vec![(start_addr, 0x400)])
     /// #    .expect("Could not create guest memory");
     /// # let addr = GuestAddress(0x1010);
     /// # let mut file = if cfg!(unix) {
@@ -286,7 +286,7 @@ impl<B: Bitmap> Bytes<MemoryRegionAddress> for GuestRegionMmap<B> {
     /// # use std::path::Path;
     /// #
     /// # let start_addr = GuestAddress(0x1000);
-    /// # let gm = GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x400)])
+    /// # let gm = GuestMemoryMmap::<()>::from_ranges(&vec![(start_addr, 0x400)])
     /// #    .expect("Could not create guest memory");
     /// # let addr = GuestAddress(0x1010);
     /// # let mut file = if cfg!(unix) {
@@ -333,7 +333,7 @@ impl<B: Bitmap> Bytes<MemoryRegionAddress> for GuestRegionMmap<B> {
     /// # use vm_memory::{Address, Bytes, GuestAddress, GuestMemoryMmap};
     /// #
     /// # let start_addr = GuestAddress(0x1000);
-    /// # let gm = GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x400)])
+    /// # let gm = GuestMemoryMmap::<()>::from_ranges(&vec![(start_addr, 0x400)])
     /// #    .expect("Could not create guest memory");
     /// # let mut file = if cfg!(unix) {
     /// # use std::fs::OpenOptions;
@@ -378,7 +378,7 @@ impl<B: Bitmap> Bytes<MemoryRegionAddress> for GuestRegionMmap<B> {
     /// # use vm_memory::{Address, Bytes, GuestAddress, GuestMemoryMmap};
     /// #
     /// # let start_addr = GuestAddress(0x1000);
-    /// # let gm = GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x400)])
+    /// # let gm = GuestMemoryMmap::<()>::from_ranges(&vec![(start_addr, 0x400)])
     /// #    .expect("Could not create guest memory");
     /// # let mut file = if cfg!(unix) {
     /// # use std::fs::OpenOptions;

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -22,6 +22,7 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use crate::address::Address;
+use crate::bitmap::{Bitmap, BS};
 use crate::guest_memory::{
     self, FileOffset, GuestAddress, GuestMemory, GuestMemoryIterator, GuestMemoryRegion,
     GuestUsize, MemoryRegionAddress,
@@ -37,6 +38,16 @@ pub use crate::mmap_windows::MmapRegion;
 #[cfg(windows)]
 pub use std::io::Error as MmapRegionError;
 
+/// A `Bitmap` that can be created starting from an initial size.
+pub trait NewBitmap: Bitmap + Default {
+    /// Create a new object based on the specified length in bytes.
+    fn with_len(len: usize) -> Self;
+}
+
+impl NewBitmap for () {
+    fn with_len(_len: usize) -> Self {}
+}
+
 /// Trait implemented by the underlying `MmapRegion`.
 pub(crate) trait AsSlice {
     /// Returns a slice corresponding to the data in the underlying `MmapRegion`.
@@ -50,7 +61,9 @@ pub(crate) trait AsSlice {
     ///
     /// # Safety
     ///
-    /// This is unsafe because of possible aliasing.
+    /// This is unsafe because of possible aliasing. Accesses done through the resulting slice
+    /// are not visible to dirty bitmap tracking functionality (when present), and have to be
+    /// explicitly accounted for.
     #[allow(clippy::mut_from_ref)]
     unsafe fn as_mut_slice(&self) -> &mut [u8];
 }
@@ -125,17 +138,26 @@ pub fn check_file_offset(
 /// Represents a continuous region of the guest's physical memory that is backed by a mapping
 /// in the virtual address space of the calling process.
 #[derive(Debug)]
-pub struct GuestRegionMmap {
-    mapping: MmapRegion,
+pub struct GuestRegionMmap<B> {
+    mapping: MmapRegion<B>,
     guest_base: GuestAddress,
 }
 
-impl GuestRegionMmap {
+impl<B> Deref for GuestRegionMmap<B> {
+    type Target = MmapRegion<B>;
+
+    fn deref(&self) -> &MmapRegion<B> {
+        &self.mapping
+    }
+}
+
+impl<B: Bitmap> GuestRegionMmap<B> {
     /// Create a new memory-mapped memory region for the guest's physical memory.
-    pub fn new(mapping: MmapRegion, guest_base: GuestAddress) -> result::Result<Self, Error> {
-        if guest_base.0.checked_add(mapping.len() as u64).is_none() {
+    pub fn new(mapping: MmapRegion<B>, guest_base: GuestAddress) -> result::Result<Self, Error> {
+        if guest_base.0.checked_add(mapping.size() as u64).is_none() {
             return Err(Error::InvalidGuestRegion);
         }
+
         Ok(GuestRegionMmap {
             mapping,
             guest_base,
@@ -143,15 +165,7 @@ impl GuestRegionMmap {
     }
 }
 
-impl Deref for GuestRegionMmap {
-    type Target = MmapRegion;
-
-    fn deref(&self) -> &MmapRegion {
-        &self.mapping
-    }
-}
-
-impl Bytes<MemoryRegionAddress> for GuestRegionMmap {
+impl<B: Bitmap> Bytes<MemoryRegionAddress> for GuestRegionMmap<B> {
     type E = guest_memory::Error;
 
     /// # Examples
@@ -419,13 +433,31 @@ impl Bytes<MemoryRegionAddress> for GuestRegionMmap {
     }
 }
 
-impl GuestMemoryRegion for GuestRegionMmap {
+impl<B: Bitmap> GuestMemoryRegion for GuestRegionMmap<B> {
+    type B = B;
+
     fn len(&self) -> GuestUsize {
-        self.mapping.len() as GuestUsize
+        self.mapping.size() as GuestUsize
     }
 
     fn start_addr(&self) -> GuestAddress {
         self.guest_base
+    }
+
+    fn bitmap(&self) -> &Self::B {
+        self.mapping.bitmap()
+    }
+
+    fn get_host_address(&self, addr: MemoryRegionAddress) -> guest_memory::Result<*mut u8> {
+        // Not sure why wrapping_offset is not unsafe.  Anyway this
+        // is safe because we've just range-checked addr using check_address.
+        self.check_address(addr)
+            .ok_or(guest_memory::Error::InvalidBackendAddress)
+            .map(|addr| {
+                self.mapping
+                    .as_ptr()
+                    .wrapping_offset(addr.raw_value() as isize)
+            })
     }
 
     fn file_offset(&self) -> Option<&FileOffset> {
@@ -440,19 +472,11 @@ impl GuestMemoryRegion for GuestRegionMmap {
         Some(self.mapping.as_mut_slice())
     }
 
-    fn get_host_address(&self, addr: MemoryRegionAddress) -> guest_memory::Result<*mut u8> {
-        // Not sure why wrapping_offset is not unsafe.  Anyway this
-        // is safe because we've just range-checked addr using check_address.
-        self.check_address(addr)
-            .ok_or(guest_memory::Error::InvalidBackendAddress)
-            .map(|addr| self.as_ptr().wrapping_offset(addr.raw_value() as isize))
-    }
-
     fn get_slice(
         &self,
         offset: MemoryRegionAddress,
         count: usize,
-    ) -> guest_memory::Result<VolatileSlice> {
+    ) -> guest_memory::Result<VolatileSlice<BS<B>>> {
         let slice = self.mapping.get_slice(offset.raw_value() as usize, count)?;
         Ok(slice)
     }
@@ -470,11 +494,11 @@ impl GuestMemoryRegion for GuestRegionMmap {
 /// Each region is an instance of `GuestRegionMmap`, being backed by a mapping in the
 /// virtual address space of the calling process.
 #[derive(Clone, Debug, Default)]
-pub struct GuestMemoryMmap {
-    regions: Vec<Arc<GuestRegionMmap>>,
+pub struct GuestMemoryMmap<B> {
+    regions: Vec<Arc<GuestRegionMmap<B>>>,
 }
 
-impl GuestMemoryMmap {
+impl<B: NewBitmap> GuestMemoryMmap<B> {
     /// Creates an empty `GuestMemoryMmap` instance.
     pub fn new() -> Self {
         Self::default()
@@ -514,7 +538,9 @@ impl GuestMemoryMmap {
                 .collect::<result::Result<Vec<_>, Error>>()?,
         )
     }
+}
 
+impl<B: Bitmap> GuestMemoryMmap<B> {
     /// Creates a new `GuestMemoryMmap` from a vector of regions.
     ///
     /// # Arguments
@@ -522,7 +548,7 @@ impl GuestMemoryMmap {
     /// * `regions` - The vector of regions.
     ///               The regions shouldn't overlap and they should be sorted
     ///               by the starting address.
-    pub fn from_regions(mut regions: Vec<GuestRegionMmap>) -> result::Result<Self, Error> {
+    pub fn from_regions(mut regions: Vec<GuestRegionMmap<B>>) -> result::Result<Self, Error> {
         Self::from_arc_regions(regions.drain(..).map(Arc::new).collect())
     }
 
@@ -538,7 +564,7 @@ impl GuestMemoryMmap {
     /// * `regions` - The vector of `Arc` regions.
     ///               The regions shouldn't overlap and they should be sorted
     ///               by the starting address.
-    pub fn from_arc_regions(regions: Vec<Arc<GuestRegionMmap>>) -> result::Result<Self, Error> {
+    pub fn from_arc_regions(regions: Vec<Arc<GuestRegionMmap<B>>>) -> result::Result<Self, Error> {
         if regions.is_empty() {
             return Err(Error::NoMemoryRegion);
         }
@@ -565,8 +591,8 @@ impl GuestMemoryMmap {
     /// * `region`: the memory region to insert into the guest memory object.
     pub fn insert_region(
         &self,
-        region: Arc<GuestRegionMmap>,
-    ) -> result::Result<GuestMemoryMmap, Error> {
+        region: Arc<GuestRegionMmap<B>>,
+    ) -> result::Result<GuestMemoryMmap<B>, Error> {
         let mut regions = self.regions.clone();
         regions.push(region);
         regions.sort_by_key(|x| x.start_addr());
@@ -584,9 +610,9 @@ impl GuestMemoryMmap {
         &self,
         base: GuestAddress,
         size: GuestUsize,
-    ) -> result::Result<(GuestMemoryMmap, Arc<GuestRegionMmap>), Error> {
+    ) -> result::Result<(GuestMemoryMmap<B>, Arc<GuestRegionMmap<B>>), Error> {
         if let Ok(region_index) = self.regions.binary_search_by_key(&base, |x| x.start_addr()) {
-            if self.regions.get(region_index).unwrap().size() as GuestUsize == size {
+            if self.regions.get(region_index).unwrap().mapping.size() as GuestUsize == size {
                 let mut regions = self.regions.clone();
                 let region = regions.remove(region_index);
                 return Ok((Self { regions }, region));
@@ -600,21 +626,21 @@ impl GuestMemoryMmap {
 /// An iterator over the elements of `GuestMemoryMmap`.
 ///
 /// This struct is created by `GuestMemory::iter()`. See its documentation for more.
-pub struct Iter<'a>(std::slice::Iter<'a, Arc<GuestRegionMmap>>);
+pub struct Iter<'a, B>(std::slice::Iter<'a, Arc<GuestRegionMmap<B>>>);
 
-impl<'a> Iterator for Iter<'a> {
-    type Item = &'a GuestRegionMmap;
+impl<'a, B> Iterator for Iter<'a, B> {
+    type Item = &'a GuestRegionMmap<B>;
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next().map(AsRef::as_ref)
     }
 }
 
-impl<'a> GuestMemoryIterator<'a, GuestRegionMmap> for GuestMemoryMmap {
-    type Iter = Iter<'a>;
+impl<'a, B: 'a> GuestMemoryIterator<'a, GuestRegionMmap<B>> for GuestMemoryMmap<B> {
+    type Iter = Iter<'a, B>;
 }
 
-impl GuestMemory for GuestMemoryMmap {
-    type R = GuestRegionMmap;
+impl<B: Bitmap + 'static> GuestMemory for GuestMemoryMmap<B> {
+    type R = GuestRegionMmap<B>;
 
     type I = Self;
 
@@ -622,7 +648,7 @@ impl GuestMemory for GuestMemoryMmap {
         self.regions.len()
     }
 
-    fn find_region(&self, addr: GuestAddress) -> Option<&GuestRegionMmap> {
+    fn find_region(&self, addr: GuestAddress) -> Option<&GuestRegionMmap<B>> {
         let index = match self.regions.binary_search_by_key(&addr, |x| x.start_addr()) {
             Ok(x) => Some(x),
             // Within the closest region with starting address < addr
@@ -632,7 +658,7 @@ impl GuestMemory for GuestMemoryMmap {
         index.map(|x| self.regions[x].as_ref())
     }
 
-    fn iter(&self) -> Iter {
+    fn iter(&self) -> Iter<B> {
         Iter(self.regions.iter())
     }
 }
@@ -642,17 +668,22 @@ mod tests {
     extern crate vmm_sys_util;
 
     use super::*;
-    use crate::GuestAddressSpace;
+
+    use crate::{GuestAddressSpace, GuestMemory, GuestMemoryRegion, VolatileMemory};
 
     use std::fs::File;
     use std::mem;
     use std::path::Path;
     use vmm_sys_util::tempfile::TempFile;
 
+    type GuestMemoryMmap = super::GuestMemoryMmap<()>;
+    type GuestRegionMmap = super::GuestRegionMmap<()>;
+    type MmapRegion = super::MmapRegion<()>;
+
     #[test]
     fn basic_map() {
         let m = MmapRegion::new(1024).unwrap();
-        assert_eq!(1024, m.len());
+        assert_eq!(1024, m.size());
     }
 
     fn check_guest_memory_mmap(
@@ -899,8 +930,8 @@ mod tests {
 
     #[test]
     fn slice_addr() {
-        let m = MmapRegion::new(5).unwrap();
-        let s = m.get_slice(2, 3).unwrap();
+        let m = GuestRegionMmap::new(MmapRegion::new(5).unwrap(), GuestAddress(0)).unwrap();
+        let s = m.get_slice(MemoryRegionAddress(2), 3).unwrap();
         assert_eq!(s.as_ptr(), unsafe { m.as_ptr().offset(2) });
     }
 
@@ -910,10 +941,11 @@ mod tests {
         let sample_buf = &[1, 2, 3, 4, 5];
         assert!(f.write_all(sample_buf).is_ok());
 
-        let mem_map = MmapRegion::from_file(FileOffset::new(f, 0), sample_buf.len()).unwrap();
+        let region = MmapRegion::from_file(FileOffset::new(f, 0), sample_buf.len()).unwrap();
+        let mem_map = GuestRegionMmap::new(region, GuestAddress(0)).unwrap();
         let buf = &mut [0u8; 16];
         assert_eq!(
-            mem_map.as_volatile_slice().read(buf, 0).unwrap(),
+            mem_map.as_volatile_slice().unwrap().read(buf, 0).unwrap(),
             sample_buf.len()
         );
         assert_eq!(buf[0..sample_buf.len()], sample_buf[..]);

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -669,6 +669,8 @@ mod tests {
 
     use super::*;
 
+    use crate::bitmap::tests::test_guest_memory_and_region;
+    use crate::bitmap::AtomicBitmap;
     use crate::{GuestAddressSpace, GuestMemory, GuestMemoryRegion, VolatileMemory};
 
     use std::fs::File;
@@ -1557,5 +1559,13 @@ mod tests {
             MemoryRegionAddress(0),
             MemoryRegionAddress(0x1000),
         );
+    }
+
+    #[test]
+    fn test_dirty_tracking() {
+        test_guest_memory_and_region(|| {
+            crate::GuestMemoryMmap::<AtomicBitmap>::from_ranges(&[(GuestAddress(0), 0x1_0000)])
+                .unwrap()
+        });
     }
 }

--- a/src/mmap_unix.rs
+++ b/src/mmap_unix.rs
@@ -17,8 +17,9 @@ use std::os::unix::io::AsRawFd;
 use std::ptr::null_mut;
 use std::result;
 
+use crate::bitmap::{Bitmap, BS};
 use crate::guest_memory::FileOffset;
-use crate::mmap::{check_file_offset, AsSlice};
+use crate::mmap::{check_file_offset, AsSlice, NewBitmap};
 use crate::volatile_memory::{self, compute_offset, VolatileMemory, VolatileSlice};
 
 /// Error conditions that may arise when creating a new `MmapRegion` object.
@@ -83,9 +84,10 @@ pub type Result<T> = result::Result<T, Error>;
 /// physical memory may be mapped into the current process due to the limited virtual address
 /// space size of the process.
 #[derive(Debug)]
-pub struct MmapRegion {
+pub struct MmapRegion<B> {
     addr: *mut u8,
     size: usize,
+    bitmap: B,
     file_offset: Option<FileOffset>,
     prot: i32,
     flags: i32,
@@ -97,10 +99,10 @@ pub struct MmapRegion {
 // Accessing that pointer is only done through the stateless interface which
 // allows the object to be shared by multiple threads without a decrease in
 // safety.
-unsafe impl Send for MmapRegion {}
-unsafe impl Sync for MmapRegion {}
+unsafe impl<B: Send> Send for MmapRegion<B> {}
+unsafe impl<B: Sync> Sync for MmapRegion<B> {}
 
-impl MmapRegion {
+impl<B: NewBitmap> MmapRegion<B> {
     /// Creates a shared anonymous mapping of `size` bytes.
     ///
     /// # Arguments
@@ -169,6 +171,7 @@ impl MmapRegion {
         Ok(Self {
             addr: addr as *mut u8,
             size,
+            bitmap: B::with_len(size),
             file_offset,
             prot,
             flags,
@@ -211,6 +214,7 @@ impl MmapRegion {
         Ok(Self {
             addr,
             size,
+            bitmap: B::with_len(size),
             file_offset: None,
             prot,
             flags,
@@ -218,7 +222,9 @@ impl MmapRegion {
             hugetlbfs: None,
         })
     }
+}
 
+impl<B: Bitmap> MmapRegion<B> {
     /// Returns a pointer to the beginning of the memory region.
     ///
     /// Should only be used for passing this region to ioctls for setting guest memory.
@@ -256,7 +262,7 @@ impl MmapRegion {
     ///
     /// This is mostly a sanity check available for convenience, as different file descriptors
     /// can alias the same file.
-    pub fn fds_overlap(&self, other: &MmapRegion) -> bool {
+    pub fn fds_overlap<T: Bitmap>(&self, other: &MmapRegion<T>) -> bool {
         if let Some(f_off1) = self.file_offset() {
             if let Some(f_off2) = other.file_offset() {
                 if f_off1.file().as_raw_fd() == f_off2.file().as_raw_fd() {
@@ -285,9 +291,14 @@ impl MmapRegion {
     pub fn is_hugetlbfs(&self) -> Option<bool> {
         self.hugetlbfs
     }
+
+    /// Returns a reference to the inner bitmap object.
+    pub fn bitmap(&self) -> &B {
+        &self.bitmap
+    }
 }
 
-impl AsSlice for MmapRegion {
+impl<B> AsSlice for MmapRegion<B> {
     unsafe fn as_slice(&self) -> &[u8] {
         // This is safe because we mapped the area at addr ourselves, so this slice will not
         // overflow. However, it is possible to alias.
@@ -302,12 +313,18 @@ impl AsSlice for MmapRegion {
     }
 }
 
-impl VolatileMemory for MmapRegion {
+impl<B: Bitmap> VolatileMemory for MmapRegion<B> {
+    type B = B;
+
     fn len(&self) -> usize {
         self.size
     }
 
-    fn get_slice(&self, offset: usize, count: usize) -> volatile_memory::Result<VolatileSlice> {
+    fn get_slice(
+        &self,
+        offset: usize,
+        count: usize,
+    ) -> volatile_memory::Result<VolatileSlice<BS<B>>> {
         let end = compute_offset(offset, count)?;
         if end > self.size {
             return Err(volatile_memory::Error::OutOfBounds { addr: end });
@@ -315,11 +332,17 @@ impl VolatileMemory for MmapRegion {
 
         // Safe because we checked that offset + count was within our range and we only ever hand
         // out volatile accessors.
-        Ok(unsafe { VolatileSlice::new((self.addr as usize + offset) as *mut _, count) })
+        Ok(unsafe {
+            VolatileSlice::new(
+                (self.addr as usize + offset) as *mut _,
+                count,
+                self.bitmap.slice_at(offset),
+            )
+        })
     }
 }
 
-impl Drop for MmapRegion {
+impl<B> Drop for MmapRegion<B> {
     fn drop(&mut self) {
         // This is safe because we mmap the area at addr ourselves, and nobody
         // else is holding a reference to it.
@@ -339,6 +362,8 @@ mod tests {
     use std::slice;
     use std::sync::Arc;
     use vmm_sys_util::tempfile::TempFile;
+
+    type MmapRegion = super::MmapRegion<()>;
 
     // Adding a helper method to extract the errno within an Error::Mmap(e), or return a
     // distinctive value when the error is represented by another variant.

--- a/src/mmap_unix.rs
+++ b/src/mmap_unix.rs
@@ -363,6 +363,8 @@ mod tests {
     use std::sync::Arc;
     use vmm_sys_util::tempfile::TempFile;
 
+    use crate::bitmap::AtomicBitmap;
+
     type MmapRegion = super::MmapRegion<()>;
 
     // Adding a helper method to extract the errno within an Error::Mmap(e), or return a
@@ -557,5 +559,13 @@ mod tests {
         // R2 is not file backed, so no overlap.
         let r2 = MmapRegion::new(5000).unwrap();
         assert!(!r1.fds_overlap(&r2));
+    }
+
+    #[test]
+    fn test_dirty_tracking() {
+        // Using the `crate` prefix because we aliased `MmapRegion` to `MmapRegion<()>` for
+        // the rest of the unit tests above.
+        let m = crate::MmapRegion::<AtomicBitmap>::new(0x1_0000).unwrap();
+        crate::bitmap::tests::test_volatile_memory(&m);
     }
 }

--- a/src/mmap_windows.rs
+++ b/src/mmap_windows.rs
@@ -12,8 +12,9 @@ use libc::{c_void, size_t};
 
 use winapi::um::errhandlingapi::GetLastError;
 
+use crate::bitmap::{Bitmap, BS};
 use crate::guest_memory::FileOffset;
-use crate::mmap::AsSlice;
+use crate::mmap::{AsSlice, NewBitmap};
 use crate::volatile_memory::{self, compute_offset, VolatileMemory, VolatileSlice};
 
 #[allow(non_snake_case)]
@@ -70,9 +71,10 @@ pub const ERROR_INVALID_PARAMETER: i32 = 87;
 /// physical memory may be mapped into the current process due to the limited virtual address
 /// space size of the process.
 #[derive(Debug)]
-pub struct MmapRegion {
+pub struct MmapRegion<B> {
     addr: *mut u8,
     size: usize,
+    bitmap: B,
     file_offset: Option<FileOffset>,
 }
 
@@ -80,10 +82,10 @@ pub struct MmapRegion {
 // Accessing that pointer is only done through the stateless interface which
 // allows the object to be shared by multiple threads without a decrease in
 // safety.
-unsafe impl Send for MmapRegion {}
-unsafe impl Sync for MmapRegion {}
+unsafe impl<B: Send> Send for MmapRegion<B> {}
+unsafe impl<B: Sync> Sync for MmapRegion<B> {}
 
-impl MmapRegion {
+impl<B: NewBitmap> MmapRegion<B> {
     /// Creates a shared anonymous mapping of `size` bytes.
     ///
     /// # Arguments
@@ -101,6 +103,7 @@ impl MmapRegion {
         Ok(Self {
             addr: addr as *mut u8,
             size,
+            bitmap: B::with_len(size),
             file_offset: None,
         })
     }
@@ -155,10 +158,13 @@ impl MmapRegion {
         Ok(Self {
             addr: addr as *mut u8,
             size,
+            bitmap: B::with_len(size),
             file_offset: Some(file_offset),
         })
     }
+}
 
+impl<B: Bitmap> MmapRegion<B> {
     /// Returns a pointer to the beginning of the memory region.
     ///
     /// Should only be used for passing this region to ioctls for setting guest memory.
@@ -175,9 +181,14 @@ impl MmapRegion {
     pub fn file_offset(&self) -> Option<&FileOffset> {
         self.file_offset.as_ref()
     }
+
+    /// Returns a reference to the inner bitmap object.
+    pub fn bitmap(&self) -> &B {
+        &self.bitmap
+    }
 }
 
-impl AsSlice for MmapRegion {
+impl<B> AsSlice for MmapRegion<B> {
     unsafe fn as_slice(&self) -> &[u8] {
         // This is safe because we mapped the area at addr ourselves, so this slice will not
         // overflow. However, it is possible to alias.
@@ -192,12 +203,18 @@ impl AsSlice for MmapRegion {
     }
 }
 
-impl VolatileMemory for MmapRegion {
+impl<B: Bitmap> VolatileMemory for MmapRegion<B> {
+    type B = B;
+
     fn len(&self) -> usize {
         self.size
     }
 
-    fn get_slice(&self, offset: usize, count: usize) -> volatile_memory::Result<VolatileSlice> {
+    fn get_slice(
+        &self,
+        offset: usize,
+        count: usize,
+    ) -> volatile_memory::Result<VolatileSlice<BS<Self::B>>> {
         let end = compute_offset(offset, count)?;
         if end > self.size {
             return Err(volatile_memory::Error::OutOfBounds { addr: end });
@@ -205,11 +222,17 @@ impl VolatileMemory for MmapRegion {
 
         // Safe because we checked that offset + count was within our range and we only ever hand
         // out volatile accessors.
-        Ok(unsafe { VolatileSlice::new((self.addr as usize + offset) as *mut _, count) })
+        Ok(unsafe {
+            VolatileSlice::new(
+                (self.addr as usize + offset) as *mut _,
+                count,
+                self.bitmap.slice_at(offset),
+            )
+        })
     }
 }
 
-impl Drop for MmapRegion {
+impl<B> Drop for MmapRegion<B> {
     fn drop(&mut self) {
         // This is safe because we mmap the area at addr ourselves, and nobody
         // else is holding a reference to it.
@@ -233,9 +256,13 @@ impl Drop for MmapRegion {
 
 #[cfg(test)]
 mod tests {
-    use crate::guest_memory::FileOffset;
-    use crate::mmap_windows::{MmapRegion, INVALID_HANDLE_VALUE};
     use std::os::windows::io::FromRawHandle;
+
+    use crate::bitmap::AtomicBitmap;
+    use crate::guest_memory::FileOffset;
+    use crate::mmap_windows::INVALID_HANDLE_VALUE;
+
+    type MmapRegion = super::MmapRegion<()>;
 
     #[test]
     fn map_invalid_handle() {
@@ -243,5 +270,13 @@ mod tests {
         let file_offset = FileOffset::new(file, 0);
         let e = MmapRegion::from_file(file_offset, 1024).unwrap_err();
         assert_eq!(e.raw_os_error(), Some(libc::EBADF));
+    }
+
+    #[test]
+    fn test_dirty_tracking() {
+        // Using the `crate` prefix because we aliased `MmapRegion` to `MmapRegion<()>` for
+        // the rest of the unit tests above.
+        let m = crate::MmapRegion::<AtomicBitmap>::new(0x1_0000).unwrap();
+        crate::bitmap::tests::test_volatile_memory(&m);
     }
 }

--- a/src/volatile_memory.rs
+++ b/src/volatile_memory.rs
@@ -1303,6 +1303,7 @@ mod tests {
     use super::*;
 
     use std::fs::File;
+    use std::mem::size_of_val;
     use std::path::Path;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
@@ -1311,6 +1312,11 @@ mod tests {
 
     use matches::assert_matches;
     use vmm_sys_util::tempfile::TempFile;
+
+    use crate::bitmap::tests::{
+        check_range, range_is_clean, range_is_dirty, test_bytes, test_volatile_memory,
+    };
+    use crate::bitmap::{AtomicBitmap, RefSlice};
 
     #[derive(Clone)]
     struct VecMem {
@@ -1932,5 +1938,140 @@ mod tests {
         assert_eq!(end.len(), 0);
         let err = vslice.split_at(33).unwrap_err();
         assert_matches!(err, Error::OutOfBounds { addr: _ })
+    }
+
+    #[test]
+    fn test_volatile_slice_dirty_tracking() {
+        let val = 123u64;
+        let dirty_offset = 0x1000;
+        let dirty_len = size_of_val(&val);
+        let page_size = 0x1000;
+
+        let mut buf = vec![0u8; 0x10000];
+
+        // Invoke the `Bytes` test helper function.
+        {
+            let bitmap = AtomicBitmap::new(buf.len(), page_size);
+            let slice =
+                unsafe { VolatileSlice::new(buf.as_mut_ptr(), buf.len(), bitmap.slice_at(0)) };
+
+            test_bytes(
+                &slice,
+                |s: &VolatileSlice<RefSlice<AtomicBitmap>>,
+                 start: usize,
+                 len: usize,
+                 clean: bool| { check_range(s.bitmap(), start, len, clean) },
+                |offset| offset,
+                0x1000,
+            );
+        }
+
+        // Invoke the `VolatileMemory` test helper function.
+        {
+            let bitmap = AtomicBitmap::new(buf.len(), page_size);
+            let slice =
+                unsafe { VolatileSlice::new(buf.as_mut_ptr(), buf.len(), bitmap.slice_at(0)) };
+            test_volatile_memory(&slice);
+        }
+
+        let bitmap = AtomicBitmap::new(buf.len(), page_size);
+        let slice = unsafe { VolatileSlice::new(buf.as_mut_ptr(), buf.len(), bitmap.slice_at(0)) };
+
+        let bitmap2 = AtomicBitmap::new(buf.len(), page_size);
+        let slice2 =
+            unsafe { VolatileSlice::new(buf.as_mut_ptr(), buf.len(), bitmap2.slice_at(0)) };
+
+        assert!(range_is_clean(slice.bitmap(), 0, slice.len()));
+        assert!(range_is_clean(slice2.bitmap(), 0, slice2.len()));
+
+        slice.write_obj(val, dirty_offset).unwrap();
+        assert!(range_is_dirty(slice.bitmap(), dirty_offset, dirty_len));
+
+        slice.copy_to_volatile_slice(slice2);
+        assert!(range_is_dirty(slice2.bitmap(), 0, slice2.len()));
+
+        {
+            let (s1, s2) = slice.split_at(dirty_offset).unwrap();
+            assert!(range_is_clean(s1.bitmap(), 0, s1.len()));
+            assert!(range_is_dirty(s2.bitmap(), 0, dirty_len));
+        }
+
+        {
+            let s = slice.subslice(dirty_offset, dirty_len).unwrap();
+            assert!(range_is_dirty(s.bitmap(), 0, s.len()));
+        }
+
+        {
+            let s = slice.offset(dirty_offset).unwrap();
+            assert!(range_is_dirty(s.bitmap(), 0, dirty_len));
+        }
+
+        // Test `copy_from`.
+        let buf = vec![1u8; dirty_offset];
+
+        assert!(range_is_clean(slice.bitmap(), 0, dirty_offset));
+        slice.copy_from(&buf);
+        assert!(range_is_dirty(slice.bitmap(), 0, dirty_offset));
+    }
+
+    #[test]
+    fn test_volatile_ref_dirty_tracking() {
+        let val = 123u64;
+        let mut buf = vec![val];
+        let page_size = 0x1000;
+
+        let bitmap = AtomicBitmap::new(size_of_val(&val), page_size);
+        let vref = unsafe { VolatileRef::new(buf.as_mut_ptr() as *mut u8, bitmap.slice_at(0)) };
+
+        assert!(range_is_clean(vref.bitmap(), 0, vref.len()));
+        vref.store(val);
+        assert!(range_is_dirty(vref.bitmap(), 0, vref.len()));
+    }
+
+    #[test]
+    fn test_volatile_array_ref_dirty_tracking() {
+        let val = 123u64;
+        let dirty_len = size_of_val(&val);
+        let index = 0x1000;
+        let dirty_offset = dirty_len * index;
+        let page_size = 0x1000;
+
+        let mut buf = vec![0u64; index + 1];
+
+        {
+            let bitmap = AtomicBitmap::new(buf.len() * size_of_val(&val), page_size);
+            let arr = unsafe {
+                VolatileArrayRef::new(buf.as_mut_ptr() as *mut u8, index + 1, bitmap.slice_at(0))
+            };
+
+            assert!(range_is_clean(arr.bitmap(), 0, arr.len() * dirty_len));
+            arr.ref_at(index).store(val);
+            assert!(range_is_dirty(arr.bitmap(), dirty_offset, dirty_len));
+        }
+
+        {
+            let bitmap = AtomicBitmap::new(buf.len() * size_of_val(&val), page_size);
+            let arr = unsafe {
+                VolatileArrayRef::new(buf.as_mut_ptr() as *mut u8, index + 1, bitmap.slice_at(0))
+            };
+
+            let slice = arr.to_slice();
+            assert!(range_is_clean(slice.bitmap(), 0, slice.len()));
+            arr.ref_at(index).store(val);
+            assert!(range_is_dirty(slice.bitmap(), dirty_offset, dirty_len));
+        }
+
+        {
+            let bitmap = AtomicBitmap::new(buf.len() * size_of_val(&val), page_size);
+            let arr = unsafe {
+                VolatileArrayRef::new(buf.as_mut_ptr() as *mut u8, index + 1, bitmap.slice_at(0))
+            };
+
+            let copy_buf = vec![val; index + 1];
+
+            assert!(range_is_clean(arr.bitmap(), 0, arr.len() * dirty_len));
+            arr.copy_from(copy_buf.as_slice());
+            assert!(range_is_dirty(arr.bitmap(), 0, buf.len() * dirty_len));
+        }
     }
 }


### PR DESCRIPTION
These changes are mainly from the pending PR (https://github.com/rust-vmm/vm-memory/pull/125) from the upstream vm-memory crate with the following changes:
1. Rebased on top of the latest master branch;
2. Added the function 'AtomicBitmap::get_and_reset()'.

We are planning to rely on our custom fork of the vm-memory crate before the dirty-page-tracking PR is landed in the upstream.